### PR TITLE
Remove equipment and hints from VirtualLab experiments

### DIFF
--- a/client/src/components/VirtualLab/VirtualLabApp.tsx
+++ b/client/src/components/VirtualLab/VirtualLabApp.tsx
@@ -350,16 +350,7 @@ function VirtualLabApp({
         { id: "beaker", name: "Beaker", icon: <Beaker size={36} /> },
       ];
     } else if (experimentTitle.includes("Equilibrium")) {
-      return [
-        { id: "test_tubes", name: "Test Tubes", icon: <TestTube size={36} /> },
-        { id: "beakers", name: "Beakers", icon: <Beaker size={36} /> },
-        {
-          id: "hot_water_bath",
-          name: "Hot Water Bath",
-          icon: <Thermometer size={36} />,
-        },
-        { id: "ice_bath", name: "Ice Bath", icon: <FlaskConical size={36} /> },
-      ];
+      return [];
     }
     return [];
   }, [experimentTitle]);

--- a/client/src/components/VirtualLab/VirtualLabApp.tsx
+++ b/client/src/components/VirtualLab/VirtualLabApp.tsx
@@ -352,12 +352,6 @@ function VirtualLabApp({
     } else if (experimentTitle.includes("Equilibrium")) {
       return [
         { id: "test_tubes", name: "Test Tubes", icon: <TestTube size={36} /> },
-        { id: "beakers", name: "Beakers", icon: <Beaker size={36} /> },
-        {
-          id: "hot_water_bath",
-          name: "Hot Water Bath",
-          icon: <Thermometer size={36} />,
-        },
         { id: "ice_bath", name: "Ice Bath", icon: <FlaskConical size={36} /> },
       ];
     }

--- a/client/src/components/VirtualLab/VirtualLabApp.tsx
+++ b/client/src/components/VirtualLab/VirtualLabApp.tsx
@@ -350,7 +350,16 @@ function VirtualLabApp({
         { id: "beaker", name: "Beaker", icon: <Beaker size={36} /> },
       ];
     } else if (experimentTitle.includes("Equilibrium")) {
-      return [];
+      return [
+        { id: "test_tubes", name: "Test Tubes", icon: <TestTube size={36} /> },
+        { id: "beakers", name: "Beakers", icon: <Beaker size={36} /> },
+        {
+          id: "hot_water_bath",
+          name: "Hot Water Bath",
+          icon: <Thermometer size={36} />,
+        },
+        { id: "ice_bath", name: "Ice Bath", icon: <FlaskConical size={36} /> },
+      ];
     }
     return [];
   }, [experimentTitle]);

--- a/client/src/components/VirtualLab/WorkBench.tsx
+++ b/client/src/components/VirtualLab/WorkBench.tsx
@@ -356,9 +356,8 @@ export const WorkBench: React.FC<WorkBenchProps> = ({
               <div className="absolute top-0 left-0 right-0 h-1 bg-amber-400 opacity-60"></div>
             </div>
 
-            {/* Animated Equipment - Only for experiments 2 and 3 */}
-            {(experimentTitle.includes("Acid-Base") ||
-              experimentTitle.includes("Equilibrium")) && (
+            {/* Animated Equipment - Only for Acid-Base experiment */}
+            {experimentTitle.includes("Acid-Base") && (
               <div
                 className="absolute inset-0"
                 style={{

--- a/client/src/components/VirtualLab/WorkBench.tsx
+++ b/client/src/components/VirtualLab/WorkBench.tsx
@@ -377,31 +377,6 @@ export const WorkBench: React.FC<WorkBenchProps> = ({
               </div>
             )}
 
-            {/* Helpful hints for Aspirin Synthesis */}
-            {experimentTitle.includes("Aspirin") && (
-              <div className="absolute top-6 left-6 bg-blue-100 border-2 border-blue-300 rounded-lg p-4 max-w-sm z-20">
-                <div className="flex items-center space-x-2 mb-2">
-                  <div className="w-3 h-3 bg-blue-500 rounded-full animate-pulse"></div>
-                  <span className="font-semibold text-blue-800 text-sm">
-                    Step {currentGuidedStep}
-                  </span>
-                </div>
-                <div className="text-xs text-blue-700">
-                  {currentGuidedStep === 1 &&
-                    "Drag the Erlenmeyer Flask to the workbench to begin"}
-                  {currentGuidedStep === 2 && "Add Salicylic Acid to the flask"}
-                  {currentGuidedStep === 3 &&
-                    "Add Acetic Anhydride to the flask"}
-                  {currentGuidedStep === 4 && "Add Phosphoric Acid catalyst"}
-                  {currentGuidedStep === 5 &&
-                    "Set up the Water Bath for heating"}
-                  {currentGuidedStep === 6 && "Heat the reaction mixture"}
-                  {currentGuidedStep > 6 &&
-                    "Aspirin synthesis steps completed!"}
-                </div>
-              </div>
-            )}
-
             {/* Equipment placement area with more generous spacing */}
             <div className="absolute inset-0 p-12">{children}</div>
           </div>


### PR DESCRIPTION
This change removes several UI elements from the VirtualLab component:

- Removes "Beakers" and "Hot Water Bath" equipment options from Equilibrium experiments
- Restricts animated equipment display to only Acid-Base experiments (previously shown for both Acid-Base and Equilibrium)
- Removes the entire guided step hints section for Aspirin Synthesis experiments

The changes simplify the equipment selection and remove step-by-step guidance for certain experiment types.

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 1`

🔗 [Edit in Builder.io](https://builder.io/app/projects/a4f480d2a9274110ae362c4438c3d836/pixel-realm)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>a4f480d2a9274110ae362c4438c3d836</projectId>-->
<!--<branchName>pixel-realm</branchName>-->