### PR TITLE
Add cobalt chloride solid state image to test tube

### DIFF
--- a/client/src/components/VirtualLab/Equipment.tsx
+++ b/client/src/components/VirtualLab/Equipment.tsx
@@ -322,6 +322,22 @@ export const Equipment: React.FC<EquipmentProps> = ({
             }}
           />
 
+          {/* Cobalt chloride solid at bottom of test tube */}
+          {cobaltReactionState?.cobaltChlorideAdded &&
+            !cobaltReactionState?.distilledWaterAdded && (
+              <img
+                src="https://cdn.builder.io/api/v1/image/assets%2Fc2053654ab564f8eb91577d73cfc950b%2Fec31965a3f6f4a24bd461f0d6c1719c2?format=webp&width=800"
+                alt="Cobalt Chloride Solid"
+                className="absolute bottom-[4rem] left-1/2 transform -translate-x-1/2 w-12 h-8 object-contain transition-opacity duration-500"
+                style={{
+                  opacity:
+                    cobaltReactionState?.colorTransition === "transitioning"
+                      ? 0
+                      : 1,
+                }}
+              />
+            )}
+
           {/* Chemical composition display */}
           {chemicals.length > 0 && (
             <div className="absolute -bottom-20 left-1/2 transform -translate-x-1/2 bg-white/95 backdrop-blur-sm border border-gray-200 rounded-lg px-3 py-2 text-sm shadow-lg min-w-max">

--- a/client/src/components/VirtualLab/Equipment.tsx
+++ b/client/src/components/VirtualLab/Equipment.tsx
@@ -302,7 +302,7 @@ export const Equipment: React.FC<EquipmentProps> = ({
             key={getTestTubeImage()} // Force re-render when image changes
             src={getTestTubeImage()}
             alt="Laboratory Test Tube"
-            className={`w-64 h-[40rem] object-contain transition-all duration-[3000ms] ease-in-out ${
+            className={`w-[210px] h-[590px] object-contain transition-all duration-[3000ms] ease-in-out ${
               isDragging
                 ? "scale-108 rotate-2 brightness-115"
                 : "group-hover:scale-103 group-hover:brightness-108 group-hover:rotate-0.5"

--- a/client/src/components/VirtualLab/Equipment.tsx
+++ b/client/src/components/VirtualLab/Equipment.tsx
@@ -328,13 +328,16 @@ export const Equipment: React.FC<EquipmentProps> = ({
               <img
                 src="https://cdn.builder.io/api/v1/image/assets%2Fc2053654ab564f8eb91577d73cfc950b%2Fec31965a3f6f4a24bd461f0d6c1719c2?format=webp&width=800"
                 alt="Cobalt Chloride Solid"
-                className="absolute bottom-[1.5rem] left-1/2 transform -translate-x-1/2 w-8 h-6 object-contain transition-opacity duration-500"
+                className="absolute w-6 h-4 object-contain transition-opacity duration-500"
                 style={{
+                  bottom: "15%",
+                  left: "50%",
+                  transform: "translateX(-50%)",
                   opacity:
                     cobaltReactionState?.colorTransition === "transitioning"
                       ? 0
                       : 1,
-                  zIndex: 10,
+                  zIndex: 1,
                 }}
               />
             )}

--- a/client/src/components/VirtualLab/Equipment.tsx
+++ b/client/src/components/VirtualLab/Equipment.tsx
@@ -290,6 +290,9 @@ export const Equipment: React.FC<EquipmentProps> = ({
         ) {
           // Blue liquid test tube (after adding cobalt chloride and distilled water)
           return "https://cdn.builder.io/api/v1/image/assets%2F4fe18c7cc7824ff98352705750053deb%2F0dba4a9e1cb14c0798299e02a71a75b1?format=webp&width=800";
+        } else if (cobaltReactionState?.cobaltChlorideAdded) {
+          // Test tube with cobalt chloride solid at bottom
+          return "https://cdn.builder.io/api/v1/image/assets%2Fc2053654ab564f8eb91577d73cfc950b%2F4049c3f958624bc1b8c72f54865b618d?format=webp&width=800";
         } else {
           // Default empty test tube
           return "https://cdn.builder.io/api/v1/image/assets%2F4fe18c7cc7824ff98352705750053deb%2Fa4603d4891d44fadbfe3660d27a3ae36?format=webp&width=800";

--- a/client/src/components/VirtualLab/Equipment.tsx
+++ b/client/src/components/VirtualLab/Equipment.tsx
@@ -322,26 +322,6 @@ export const Equipment: React.FC<EquipmentProps> = ({
             }}
           />
 
-          {/* Cobalt chloride solid at bottom of test tube */}
-          {cobaltReactionState?.cobaltChlorideAdded &&
-            !cobaltReactionState?.distilledWaterAdded && (
-              <img
-                src="https://cdn.builder.io/api/v1/image/assets%2Fc2053654ab564f8eb91577d73cfc950b%2Fec31965a3f6f4a24bd461f0d6c1719c2?format=webp&width=800"
-                alt="Cobalt Chloride Solid"
-                className="absolute w-6 h-4 object-contain transition-opacity duration-500"
-                style={{
-                  bottom: "15%",
-                  left: "50%",
-                  transform: "translateX(-50%)",
-                  opacity:
-                    cobaltReactionState?.colorTransition === "transitioning"
-                      ? 0
-                      : 1,
-                  zIndex: 1,
-                }}
-              />
-            )}
-
           {/* Chemical composition display */}
           {chemicals.length > 0 && (
             <div className="absolute -bottom-20 left-1/2 transform -translate-x-1/2 bg-white/95 backdrop-blur-sm border border-gray-200 rounded-lg px-3 py-2 text-sm shadow-lg min-w-max">

--- a/client/src/components/VirtualLab/Equipment.tsx
+++ b/client/src/components/VirtualLab/Equipment.tsx
@@ -290,9 +290,6 @@ export const Equipment: React.FC<EquipmentProps> = ({
         ) {
           // Blue liquid test tube (after adding cobalt chloride and distilled water)
           return "https://cdn.builder.io/api/v1/image/assets%2F4fe18c7cc7824ff98352705750053deb%2F0dba4a9e1cb14c0798299e02a71a75b1?format=webp&width=800";
-        } else if (cobaltReactionState?.cobaltChlorideAdded) {
-          // Test tube with cobalt chloride solid at bottom
-          return "https://cdn.builder.io/api/v1/image/assets%2Fc2053654ab564f8eb91577d73cfc950b%2F24b66991847542799eb4f596b0ecd16d?format=webp&width=800";
         } else {
           // Default empty test tube
           return "https://cdn.builder.io/api/v1/image/assets%2F4fe18c7cc7824ff98352705750053deb%2Fa4603d4891d44fadbfe3660d27a3ae36?format=webp&width=800";

--- a/client/src/components/VirtualLab/Equipment.tsx
+++ b/client/src/components/VirtualLab/Equipment.tsx
@@ -328,12 +328,13 @@ export const Equipment: React.FC<EquipmentProps> = ({
               <img
                 src="https://cdn.builder.io/api/v1/image/assets%2Fc2053654ab564f8eb91577d73cfc950b%2Fec31965a3f6f4a24bd461f0d6c1719c2?format=webp&width=800"
                 alt="Cobalt Chloride Solid"
-                className="absolute bottom-[4rem] left-1/2 transform -translate-x-1/2 w-12 h-8 object-contain transition-opacity duration-500"
+                className="absolute bottom-[1.5rem] left-1/2 transform -translate-x-1/2 w-8 h-6 object-contain transition-opacity duration-500"
                 style={{
                   opacity:
                     cobaltReactionState?.colorTransition === "transitioning"
                       ? 0
                       : 1,
+                  zIndex: 10,
                 }}
               />
             )}

--- a/client/src/components/VirtualLab/Equipment.tsx
+++ b/client/src/components/VirtualLab/Equipment.tsx
@@ -302,7 +302,7 @@ export const Equipment: React.FC<EquipmentProps> = ({
             key={getTestTubeImage()} // Force re-render when image changes
             src={getTestTubeImage()}
             alt="Laboratory Test Tube"
-            className={`w-[210px] h-[590px] object-contain transition-all duration-[3000ms] ease-in-out ${
+            className={`w-64 h-[40rem] object-contain transition-all duration-[3000ms] ease-in-out ${
               isDragging
                 ? "scale-108 rotate-2 brightness-115"
                 : "group-hover:scale-103 group-hover:brightness-108 group-hover:rotate-0.5"

--- a/client/src/components/VirtualLab/Equipment.tsx
+++ b/client/src/components/VirtualLab/Equipment.tsx
@@ -290,6 +290,9 @@ export const Equipment: React.FC<EquipmentProps> = ({
         ) {
           // Blue liquid test tube (after adding cobalt chloride and distilled water)
           return "https://cdn.builder.io/api/v1/image/assets%2F4fe18c7cc7824ff98352705750053deb%2F0dba4a9e1cb14c0798299e02a71a75b1?format=webp&width=800";
+        } else if (cobaltReactionState?.cobaltChlorideAdded) {
+          // Test tube with cobalt chloride solid at bottom
+          return "https://cdn.builder.io/api/v1/image/assets%2Fc2053654ab564f8eb91577d73cfc950b%2F24b66991847542799eb4f596b0ecd16d?format=webp&width=800";
         } else {
           // Default empty test tube
           return "https://cdn.builder.io/api/v1/image/assets%2F4fe18c7cc7824ff98352705750053deb%2Fa4603d4891d44fadbfe3660d27a3ae36?format=webp&width=800";


### PR DESCRIPTION
Add conditional rendering for test tube image when cobalt chloride has been added but distilled water has not yet been added.

The new condition displays an image showing cobalt chloride solid at the bottom of the test tube, providing a visual state between the empty test tube and the blue liquid state after water is added.

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 8`

🔗 [Edit in Builder.io](https://builder.io/app/projects/e39ffee87fab463ab9cefbeaaa9e8cf8/orbit-nest)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>e39ffee87fab463ab9cefbeaaa9e8cf8</projectId>-->
<!--<branchName>orbit-nest</branchName>-->