### PR TITLE
Add dynamic sizing for test tube based on cobalt reaction state

### DIFF
--- a/client/src/components/VirtualLab/Equipment.tsx
+++ b/client/src/components/VirtualLab/Equipment.tsx
@@ -308,7 +308,7 @@ export const Equipment: React.FC<EquipmentProps> = ({
             className={`${
               cobaltReactionState?.cobaltChlorideAdded &&
               cobaltReactionState?.distilledWaterAdded
-                ? "w-68 h-[42rem]"
+                ? "w-64 h-[40rem]"
                 : cobaltReactionState?.cobaltChlorideAdded
                   ? "w-[36rem] h-[90rem]"
                   : "w-64 h-[40rem]"

--- a/client/src/components/VirtualLab/Equipment.tsx
+++ b/client/src/components/VirtualLab/Equipment.tsx
@@ -308,7 +308,7 @@ export const Equipment: React.FC<EquipmentProps> = ({
             className={`${
               cobaltReactionState?.cobaltChlorideAdded &&
               cobaltReactionState?.distilledWaterAdded
-                ? "w-96 h-[60rem]"
+                ? "w-48 h-[30rem]"
                 : cobaltReactionState?.cobaltChlorideAdded
                   ? "w-[36rem] h-[90rem]"
                   : "w-64 h-[40rem]"

--- a/client/src/components/VirtualLab/Equipment.tsx
+++ b/client/src/components/VirtualLab/Equipment.tsx
@@ -305,7 +305,11 @@ export const Equipment: React.FC<EquipmentProps> = ({
             key={getTestTubeImage()} // Force re-render when image changes
             src={getTestTubeImage()}
             alt="Laboratory Test Tube"
-            className={`w-64 h-[40rem] object-contain transition-all duration-[3000ms] ease-in-out ${
+            className={`${
+              cobaltReactionState?.cobaltChlorideAdded
+                ? "w-80 h-[50rem]"
+                : "w-64 h-[40rem]"
+            } object-contain transition-all duration-[3000ms] ease-in-out ${
               isDragging
                 ? "scale-108 rotate-2 brightness-115"
                 : "group-hover:scale-103 group-hover:brightness-108 group-hover:rotate-0.5"

--- a/client/src/components/VirtualLab/Equipment.tsx
+++ b/client/src/components/VirtualLab/Equipment.tsx
@@ -308,7 +308,7 @@ export const Equipment: React.FC<EquipmentProps> = ({
             className={`${
               cobaltReactionState?.cobaltChlorideAdded &&
               cobaltReactionState?.distilledWaterAdded
-                ? "w-48 h-[30rem]"
+                ? "w-68 h-[42rem]"
                 : cobaltReactionState?.cobaltChlorideAdded
                   ? "w-[36rem] h-[90rem]"
                   : "w-64 h-[40rem]"

--- a/client/src/components/VirtualLab/Equipment.tsx
+++ b/client/src/components/VirtualLab/Equipment.tsx
@@ -307,7 +307,7 @@ export const Equipment: React.FC<EquipmentProps> = ({
             alt="Laboratory Test Tube"
             className={`${
               cobaltReactionState?.cobaltChlorideAdded
-                ? "w-96 h-[60rem]"
+                ? "w-[36rem] h-[90rem]"
                 : "w-64 h-[40rem]"
             } object-contain transition-all duration-[3000ms] ease-in-out ${
               isDragging

--- a/client/src/components/VirtualLab/Equipment.tsx
+++ b/client/src/components/VirtualLab/Equipment.tsx
@@ -307,7 +307,7 @@ export const Equipment: React.FC<EquipmentProps> = ({
             alt="Laboratory Test Tube"
             className={`${
               cobaltReactionState?.cobaltChlorideAdded
-                ? "w-80 h-[50rem]"
+                ? "w-96 h-[60rem]"
                 : "w-64 h-[40rem]"
             } object-contain transition-all duration-[3000ms] ease-in-out ${
               isDragging

--- a/client/src/components/VirtualLab/Equipment.tsx
+++ b/client/src/components/VirtualLab/Equipment.tsx
@@ -306,9 +306,12 @@ export const Equipment: React.FC<EquipmentProps> = ({
             src={getTestTubeImage()}
             alt="Laboratory Test Tube"
             className={`${
-              cobaltReactionState?.cobaltChlorideAdded
-                ? "w-[36rem] h-[90rem]"
-                : "w-64 h-[40rem]"
+              cobaltReactionState?.cobaltChlorideAdded &&
+              cobaltReactionState?.distilledWaterAdded
+                ? "w-96 h-[60rem]"
+                : cobaltReactionState?.cobaltChlorideAdded
+                  ? "w-[36rem] h-[90rem]"
+                  : "w-64 h-[40rem]"
             } object-contain transition-all duration-[3000ms] ease-in-out ${
               isDragging
                 ? "scale-108 rotate-2 brightness-115"


### PR DESCRIPTION
Updates the Equipment component to conditionally adjust test tube dimensions based on cobalt reaction state.

Changes:
- Replaces static w-64 h-[40rem] sizing with conditional logic
- Sets larger dimensions (w-[36rem] h-[90rem]) when only cobalt chloride is added
- Maintains original dimensions (w-64 h-[40rem]) when both cobalt chloride and distilled water are added or when no cobalt chloride is present
- Preserves existing transition and styling properties

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 9`

🔗 [Edit in Builder.io](https://builder.io/app/projects/7a1100fbeb864d4d8f1e6772523dd12b/vibe-oasis)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>7a1100fbeb864d4d8f1e6772523dd12b</projectId>-->
<!--<branchName>vibe-oasis</branchName>-->