### PR TITLE
Add HCl equilibrium reaction and step navigation updates

### DIFF
--- a/client/src/components/VirtualLab/Equipment.tsx
+++ b/client/src/components/VirtualLab/Equipment.tsx
@@ -426,7 +426,11 @@ export const Equipment: React.FC<EquipmentProps> = ({
       return (
         <div className="relative">
           <img
-            src="https://cdn.builder.io/api/v1/image/assets%2Fab3d7499a8fe404bb2836f6043ac08b4%2F66657d803e14427eaeecd21906ee09f6?format=webp&width=800"
+            src={
+              dropperHasHCl
+                ? "https://cdn.builder.io/api/v1/image/assets%2F9f88423319a248faa5a2c8b5f85cccbb%2Fc58de29c65a94ac897c340cd6a044ba5?format=webp&width=800"
+                : "https://cdn.builder.io/api/v1/image/assets%2Fab3d7499a8fe404bb2836f6043ac08b4%2F66657d803e14427eaeecd21906ee09f6?format=webp&width=800"
+            }
             alt="Laboratory Dropper"
             className="w-24 h-32 object-contain drop-shadow-lg"
           />

--- a/client/src/components/VirtualLab/Equipment.tsx
+++ b/client/src/components/VirtualLab/Equipment.tsx
@@ -347,12 +347,19 @@ export const Equipment: React.FC<EquipmentProps> = ({
     if (id === "test_tubes") {
       // Determine which test tube image to show based on reaction state
       const getTestTubeImage = () => {
-        // If stirrer is active and we have cobalt + water, transition to pink
-        if (
+        // Check if HCl has been added to pink solution
+        const hasHCl = chemicals.some((c) => c.id === "hcl_conc");
+        const hasPinkSolution =
           cobaltReactionState?.stirrerActive &&
           cobaltReactionState?.cobaltChlorideAdded &&
-          cobaltReactionState?.distilledWaterAdded
-        ) {
+          cobaltReactionState?.distilledWaterAdded;
+
+        // If HCl is added to pink solution, show blue solution
+        if (hasHCl && hasPinkSolution) {
+          return "https://cdn.builder.io/api/v1/image/assets%2F9f88423319a248faa5a2c8b5f85cccbb%2F0d959c0e809c4eefb0274b173c508d79?format=webp&width=800";
+        }
+        // If stirrer is active and we have cobalt + water, transition to pink
+        else if (hasPinkSolution) {
           // Pink liquid test tube (after stirring)
           return "https://cdn.builder.io/api/v1/image/assets%2F4fe18c7cc7824ff98352705750053deb%2F280bbef2140249df9531563786b4bae0?format=webp&width=800";
         } else if (

--- a/client/src/components/VirtualLab/Equipment.tsx
+++ b/client/src/components/VirtualLab/Equipment.tsx
@@ -423,12 +423,13 @@ export const Equipment: React.FC<EquipmentProps> = ({
     }
 
     if (id === "dropper") {
-      console.log("Dropper rendering with dropperHasHCl:", dropperHasHCl);
+      const hasHCl =
+        chemicals.some((c) => c.id === "hcl_conc") || dropperHasHCl;
       return (
         <div className="relative">
           <img
             src={
-              dropperHasHCl
+              hasHCl
                 ? "https://cdn.builder.io/api/v1/image/assets%2F9f88423319a248faa5a2c8b5f85cccbb%2Fc58de29c65a94ac897c340cd6a044ba5?format=webp&width=800"
                 : "https://cdn.builder.io/api/v1/image/assets%2Fab3d7499a8fe404bb2836f6043ac08b4%2F66657d803e14427eaeecd21906ee09f6?format=webp&width=800"
             }

--- a/client/src/components/VirtualLab/Equipment.tsx
+++ b/client/src/components/VirtualLab/Equipment.tsx
@@ -423,6 +423,7 @@ export const Equipment: React.FC<EquipmentProps> = ({
     }
 
     if (id === "dropper") {
+      console.log("Dropper rendering with dropperHasHCl:", dropperHasHCl);
       return (
         <div className="relative">
           <img

--- a/client/src/components/VirtualLab/Equipment.tsx
+++ b/client/src/components/VirtualLab/Equipment.tsx
@@ -421,16 +421,10 @@ export const Equipment: React.FC<EquipmentProps> = ({
     }
 
     if (id === "dropper") {
-      const hasHCl =
-        chemicals.some((c) => c.id === "hcl_conc") || dropperHasHCl;
       return (
         <div className="relative">
           <img
-            src={
-              hasHCl
-                ? "https://cdn.builder.io/api/v1/image/assets%2F9f88423319a248faa5a2c8b5f85cccbb%2Fc58de29c65a94ac897c340cd6a044ba5?format=webp&width=800"
-                : "https://cdn.builder.io/api/v1/image/assets%2Fab3d7499a8fe404bb2836f6043ac08b4%2F66657d803e14427eaeecd21906ee09f6?format=webp&width=800"
-            }
+            src="https://cdn.builder.io/api/v1/image/assets%2Fab3d7499a8fe404bb2836f6043ac08b4%2F66657d803e14427eaeecd21906ee09f6?format=webp&width=800"
             alt="Laboratory Dropper"
             className="w-24 h-32 object-contain drop-shadow-lg"
           />

--- a/client/src/components/VirtualLab/Equipment.tsx
+++ b/client/src/components/VirtualLab/Equipment.tsx
@@ -44,7 +44,6 @@ export const Equipment: React.FC<EquipmentProps> = ({
   onChemicalDrop,
   onRemove,
   cobaltReactionState,
-  dropperHasHCl = false,
 }) => {
   const [isDragOver, setIsDragOver] = useState(false);
   const [isDropping, setIsDropping] = useState(false);

--- a/client/src/components/VirtualLab/Equipment.tsx
+++ b/client/src/components/VirtualLab/Equipment.tsx
@@ -45,6 +45,7 @@ export const Equipment: React.FC<EquipmentProps> = ({
   onChemicalDrop,
   onRemove,
   cobaltReactionState,
+  dropperHasHCl = false,
 }) => {
   const [isDragOver, setIsDragOver] = useState(false);
   const [isDropping, setIsDropping] = useState(false);

--- a/client/src/components/VirtualLab/Equipment.tsx
+++ b/client/src/components/VirtualLab/Equipment.tsx
@@ -32,6 +32,7 @@ interface EquipmentProps {
     stirrerActive: boolean;
     colorTransition: "blue" | "transitioning" | "pink";
   };
+  dropperHasHCl?: boolean;
 }
 
 export const Equipment: React.FC<EquipmentProps> = ({

--- a/client/src/components/VirtualLab/Equipment.tsx
+++ b/client/src/components/VirtualLab/Equipment.tsx
@@ -350,7 +350,6 @@ export const Equipment: React.FC<EquipmentProps> = ({
         // Check if HCl has been added to pink solution
         const hasHCl = chemicals.some((c) => c.id === "hcl_conc");
         const hasPinkSolution =
-          cobaltReactionState?.stirrerActive &&
           cobaltReactionState?.cobaltChlorideAdded &&
           cobaltReactionState?.distilledWaterAdded;
 

--- a/client/src/components/VirtualLab/Equipment.tsx
+++ b/client/src/components/VirtualLab/Equipment.tsx
@@ -32,7 +32,6 @@ interface EquipmentProps {
     stirrerActive: boolean;
     colorTransition: "blue" | "transitioning" | "pink";
   };
-  dropperHasHCl?: boolean;
 }
 
 export const Equipment: React.FC<EquipmentProps> = ({

--- a/client/src/components/VirtualLab/Equipment.tsx
+++ b/client/src/components/VirtualLab/Equipment.tsx
@@ -345,8 +345,19 @@ export const Equipment: React.FC<EquipmentProps> = ({
     if (id === "test_tubes") {
       // Determine which test tube image to show based on reaction state
       const getTestTubeImage = () => {
-        // If stirrer is active and we have cobalt + water, transition to pink
+        // Check if HCl has been added to the test tube
+        const hasHCl = chemicals.some((c) => c.id === "hcl_conc");
+
+        // If HCl is added to existing solution, show blue equilibrium image
         if (
+          hasHCl &&
+          cobaltReactionState?.cobaltChlorideAdded &&
+          cobaltReactionState?.distilledWaterAdded
+        ) {
+          return "https://cdn.builder.io/api/v1/image/assets%2F9f88423319a248faa5a2c8b5f85cccbb%2Febd9b66616e24e5fb31410143537ddbc?format=webp&width=800";
+        }
+        // If stirrer is active and we have cobalt + water, transition to pink
+        else if (
           cobaltReactionState?.stirrerActive &&
           cobaltReactionState?.cobaltChlorideAdded &&
           cobaltReactionState?.distilledWaterAdded

--- a/client/src/components/VirtualLab/Equipment.tsx
+++ b/client/src/components/VirtualLab/Equipment.tsx
@@ -345,18 +345,12 @@ export const Equipment: React.FC<EquipmentProps> = ({
     if (id === "test_tubes") {
       // Determine which test tube image to show based on reaction state
       const getTestTubeImage = () => {
-        // Check if HCl has been added to pink solution
-        const hasHCl = chemicals.some((c) => c.id === "hcl_conc");
-        const hasPinkSolution =
-          cobaltReactionState?.cobaltChlorideAdded &&
-          cobaltReactionState?.distilledWaterAdded;
-
-        // If HCl is added to pink solution, show blue solution
-        if (hasHCl && hasPinkSolution) {
-          return "https://cdn.builder.io/api/v1/image/assets%2F9f88423319a248faa5a2c8b5f85cccbb%2F0d959c0e809c4eefb0274b173c508d79?format=webp&width=800";
-        }
         // If stirrer is active and we have cobalt + water, transition to pink
-        else if (hasPinkSolution) {
+        if (
+          cobaltReactionState?.stirrerActive &&
+          cobaltReactionState?.cobaltChlorideAdded &&
+          cobaltReactionState?.distilledWaterAdded
+        ) {
           // Pink liquid test tube (after stirring)
           return "https://cdn.builder.io/api/v1/image/assets%2F4fe18c7cc7824ff98352705750053deb%2F280bbef2140249df9531563786b4bae0?format=webp&width=800";
         } else if (

--- a/client/src/components/VirtualLab/ExperimentSteps.tsx
+++ b/client/src/components/VirtualLab/ExperimentSteps.tsx
@@ -81,8 +81,14 @@ export const ExperimentSteps: React.FC<ExperimentStepsProps> = ({
               <div
                 key={step.id}
                 ref={(el) => (stepRefs.current[step.id] = el)}
-                onClick={isCompleted ? undefined : () => onStepClick(step.id)}
-                className={`p-3 rounded-lg border-2 transition-all duration-200 ${getStepBgColor(step, index)} ${isCompleted ? "cursor-default" : "cursor-pointer"}`}
+                onClick={
+                  step.id >= 2 && step.id <= 7
+                    ? () => onStepClick(step.id)
+                    : isCompleted
+                      ? undefined
+                      : () => onStepClick(step.id)
+                }
+                className={`p-3 rounded-lg border-2 transition-all duration-200 ${getStepBgColor(step, index)} ${(step.id >= 2 && step.id <= 7) || !isCompleted ? "cursor-pointer" : "cursor-default"}`}
               >
                 <div className="flex items-start space-x-3">
                   <div className="flex-shrink-0 mt-0.5">

--- a/client/src/components/VirtualLab/VirtualLabApp.tsx
+++ b/client/src/components/VirtualLab/VirtualLabApp.tsx
@@ -621,21 +621,36 @@ function VirtualLabApp({
             },
           ];
 
-          // Cobalt chloride reaction logic
-          if (
-            experimentTitle.includes("Equilibrium") &&
-            equipmentId === "test_tubes"
-          ) {
-            if (chemicalId === "cocl2") {
-              setCobaltChlorideAdded(true);
-              setToastMessage(
-                "Blue cobalt chloride crystals formed in test tube!",
-              );
+          // Equilibrium experiment logic
+          if (experimentTitle.includes("Equilibrium")) {
+            // Handle HCl to dropper in step 2
+            if (
+              equipmentId === "dropper" &&
+              chemicalId === "hcl_conc" &&
+              currentStep === 2
+            ) {
+              setDropperHasHCl(true);
+              setToastMessage("Dropper filled with concentrated HCl!");
               setTimeout(() => setToastMessage(null), 3000);
-            } else if (chemicalId === "water" && cobaltChlorideAdded) {
-              setDistilledWaterAdded(true);
-              setToastMessage("Add the stirrer");
-              setTimeout(() => setToastMessage(null), 5000);
+            }
+            // Handle cobalt chloride in test tubes
+            else if (equipmentId === "test_tubes") {
+              if (chemicalId === "cocl2") {
+                setCobaltChlorideAdded(true);
+                setToastMessage(
+                  "Blue cobalt chloride crystals formed in test tube!",
+                );
+                setTimeout(() => setToastMessage(null), 3000);
+              } else if (chemicalId === "water" && cobaltChlorideAdded) {
+                setDistilledWaterAdded(true);
+                setToastMessage("Add the stirrer");
+                setTimeout(() => setToastMessage(null), 5000);
+              } else {
+                setToastMessage(
+                  `Added ${amount}mL of ${chemical.name} to ${equipmentId}`,
+                );
+                setTimeout(() => setToastMessage(null), 3000);
+              }
             } else {
               setToastMessage(
                 `Added ${amount}mL of ${chemical.name} to ${equipmentId}`,

--- a/client/src/components/VirtualLab/VirtualLabApp.tsx
+++ b/client/src/components/VirtualLab/VirtualLabApp.tsx
@@ -643,7 +643,13 @@ function VirtualLabApp({
               setToastMessage(
                 "Color changed from pink to blue as the equilibrium changed!",
               );
-              setTimeout(() => setToastMessage(null), 8000);
+              setTimeout(() => {
+                setToastMessage(null);
+                // Auto-advance to step 3
+                setCurrentStep(3);
+                setToastMessage("Moving to Step 3 automatically...");
+                setTimeout(() => setToastMessage(null), 3000);
+              }, 8000);
             } else {
               setToastMessage(
                 `Added ${amount}mL of ${chemical.name} to ${equipmentId}`,

--- a/client/src/components/VirtualLab/VirtualLabApp.tsx
+++ b/client/src/components/VirtualLab/VirtualLabApp.tsx
@@ -623,19 +623,8 @@ function VirtualLabApp({
 
           // Equilibrium experiment logic
           if (experimentTitle.includes("Equilibrium")) {
-            // Handle HCl to dropper in step 2
-            console.log("Chemical drop:", {
-              equipmentId,
-              chemicalId,
-              stepNumber,
-              experimentTitle,
-            });
-            if (
-              equipmentId === "dropper" &&
-              chemicalId === "hcl_conc" &&
-              stepNumber === 2
-            ) {
-              console.log("Setting dropperHasHCl to true");
+            // Handle HCl to dropper
+            if (equipmentId === "dropper" && chemicalId === "hcl_conc") {
               setDropperHasHCl(true);
               setToastMessage("Dropper filled with concentrated HCl!");
               setTimeout(() => setToastMessage(null), 3000);

--- a/client/src/components/VirtualLab/VirtualLabApp.tsx
+++ b/client/src/components/VirtualLab/VirtualLabApp.tsx
@@ -641,6 +641,16 @@ function VirtualLabApp({
                 setDistilledWaterAdded(true);
                 setToastMessage("Add the stirrer");
                 setTimeout(() => setToastMessage(null), 5000);
+              } else if (
+                chemicalId === "hcl_conc" &&
+                cobaltChlorideAdded &&
+                distilledWaterAdded &&
+                stirrerActive
+              ) {
+                setToastMessage(
+                  "Color of solution changes from pink to blue due to Equilibrium Change!",
+                );
+                setTimeout(() => setToastMessage(null), 4000);
               } else {
                 setToastMessage(
                   `Added ${amount}mL of ${chemical.name} to ${equipmentId}`,

--- a/client/src/components/VirtualLab/VirtualLabApp.tsx
+++ b/client/src/components/VirtualLab/VirtualLabApp.tsx
@@ -643,7 +643,7 @@ function VirtualLabApp({
               setToastMessage(
                 "Color changed from pink to blue as the equilibrium changed!",
               );
-              setTimeout(() => setToastMessage(null), 4000);
+              setTimeout(() => setToastMessage(null), 8000);
             } else {
               setToastMessage(
                 `Added ${amount}mL of ${chemical.name} to ${equipmentId}`,

--- a/client/src/components/VirtualLab/VirtualLabApp.tsx
+++ b/client/src/components/VirtualLab/VirtualLabApp.tsx
@@ -1063,6 +1063,7 @@ function VirtualLabApp({
                         stirrerActive,
                         colorTransition,
                       }}
+                      dropperHasHCl={dropperHasHCl}
                     />
                   ) : null;
                 })}

--- a/client/src/components/VirtualLab/VirtualLabApp.tsx
+++ b/client/src/components/VirtualLab/VirtualLabApp.tsx
@@ -624,11 +624,18 @@ function VirtualLabApp({
           // Equilibrium experiment logic
           if (experimentTitle.includes("Equilibrium")) {
             // Handle HCl to dropper in step 2
+            console.log("Chemical drop:", {
+              equipmentId,
+              chemicalId,
+              stepNumber,
+              experimentTitle,
+            });
             if (
               equipmentId === "dropper" &&
               chemicalId === "hcl_conc" &&
               stepNumber === 2
             ) {
+              console.log("Setting dropperHasHCl to true");
               setDropperHasHCl(true);
               setToastMessage("Dropper filled with concentrated HCl!");
               setTimeout(() => setToastMessage(null), 3000);

--- a/client/src/components/VirtualLab/VirtualLabApp.tsx
+++ b/client/src/components/VirtualLab/VirtualLabApp.tsx
@@ -1010,6 +1010,7 @@ function VirtualLabApp({
                     setDistilledWaterAdded(false);
                     setStirrerActive(false);
                     setColorTransition("pink");
+                    setDropperHasHCl(false);
                   }}
                 />
               </div>

--- a/client/src/components/VirtualLab/VirtualLabApp.tsx
+++ b/client/src/components/VirtualLab/VirtualLabApp.tsx
@@ -103,6 +103,7 @@ function VirtualLabApp({
   const [colorTransition, setColorTransition] = useState<
     "blue" | "transitioning" | "pink"
   >("pink");
+  const [dropperHasHCl, setDropperHasHCl] = useState(false);
 
   // Use dynamic experiment steps from allSteps prop
   const experimentSteps = allSteps.map((stepData, index) => ({

--- a/client/src/components/VirtualLab/VirtualLabApp.tsx
+++ b/client/src/components/VirtualLab/VirtualLabApp.tsx
@@ -635,6 +635,15 @@ function VirtualLabApp({
               setDistilledWaterAdded(true);
               setToastMessage("Add the stirrer");
               setTimeout(() => setToastMessage(null), 5000);
+            } else if (
+              chemicalId === "hcl_conc" &&
+              cobaltChlorideAdded &&
+              distilledWaterAdded
+            ) {
+              setToastMessage(
+                "Color changed from pink to blue as the equilibrium changed!",
+              );
+              setTimeout(() => setToastMessage(null), 4000);
             } else {
               setToastMessage(
                 `Added ${amount}mL of ${chemical.name} to ${equipmentId}`,

--- a/client/src/components/VirtualLab/VirtualLabApp.tsx
+++ b/client/src/components/VirtualLab/VirtualLabApp.tsx
@@ -620,42 +620,21 @@ function VirtualLabApp({
             },
           ];
 
-          // Equilibrium experiment logic
-          if (experimentTitle.includes("Equilibrium")) {
-            // Handle HCl to dropper
-            if (equipmentId === "dropper" && chemicalId === "hcl_conc") {
-              setDropperHasHCl(true);
-              setToastMessage("Dropper filled with concentrated HCl!");
+          // Cobalt chloride reaction logic
+          if (
+            experimentTitle.includes("Equilibrium") &&
+            equipmentId === "test_tubes"
+          ) {
+            if (chemicalId === "cocl2") {
+              setCobaltChlorideAdded(true);
+              setToastMessage(
+                "Blue cobalt chloride crystals formed in test tube!",
+              );
               setTimeout(() => setToastMessage(null), 3000);
-            }
-            // Handle cobalt chloride in test tubes
-            else if (equipmentId === "test_tubes") {
-              if (chemicalId === "cocl2") {
-                setCobaltChlorideAdded(true);
-                setToastMessage(
-                  "Blue cobalt chloride crystals formed in test tube!",
-                );
-                setTimeout(() => setToastMessage(null), 3000);
-              } else if (chemicalId === "water" && cobaltChlorideAdded) {
-                setDistilledWaterAdded(true);
-                setToastMessage("Add the stirrer");
-                setTimeout(() => setToastMessage(null), 5000);
-              } else if (
-                chemicalId === "hcl_conc" &&
-                cobaltChlorideAdded &&
-                distilledWaterAdded &&
-                stirrerActive
-              ) {
-                setToastMessage(
-                  "Color of solution changes from pink to blue due to Equilibrium Change!",
-                );
-                setTimeout(() => setToastMessage(null), 4000);
-              } else {
-                setToastMessage(
-                  `Added ${amount}mL of ${chemical.name} to ${equipmentId}`,
-                );
-                setTimeout(() => setToastMessage(null), 3000);
-              }
+            } else if (chemicalId === "water" && cobaltChlorideAdded) {
+              setDistilledWaterAdded(true);
+              setToastMessage("Add the stirrer");
+              setTimeout(() => setToastMessage(null), 5000);
             } else {
               setToastMessage(
                 `Added ${amount}mL of ${chemical.name} to ${equipmentId}`,

--- a/client/src/components/VirtualLab/VirtualLabApp.tsx
+++ b/client/src/components/VirtualLab/VirtualLabApp.tsx
@@ -627,7 +627,7 @@ function VirtualLabApp({
             if (
               equipmentId === "dropper" &&
               chemicalId === "hcl_conc" &&
-              currentStep === 2
+              stepNumber === 2
             ) {
               setDropperHasHCl(true);
               setToastMessage("Dropper filled with concentrated HCl!");

--- a/client/src/components/VirtualLab/VirtualLabApp.tsx
+++ b/client/src/components/VirtualLab/VirtualLabApp.tsx
@@ -994,7 +994,6 @@ function VirtualLabApp({
                     setDistilledWaterAdded(false);
                     setStirrerActive(false);
                     setColorTransition("pink");
-                    setDropperHasHCl(false);
                   }}
                 />
               </div>

--- a/client/src/components/VirtualLab/VirtualLabApp.tsx
+++ b/client/src/components/VirtualLab/VirtualLabApp.tsx
@@ -1048,7 +1048,6 @@ function VirtualLabApp({
                         stirrerActive,
                         colorTransition,
                       }}
-                      dropperHasHCl={dropperHasHCl}
                     />
                   ) : null;
                 })}

--- a/client/src/components/VirtualLab/VirtualLabApp.tsx
+++ b/client/src/components/VirtualLab/VirtualLabApp.tsx
@@ -103,7 +103,6 @@ function VirtualLabApp({
   const [colorTransition, setColorTransition] = useState<
     "blue" | "transitioning" | "pink"
   >("pink");
-  const [dropperHasHCl, setDropperHasHCl] = useState(false);
 
   // Use dynamic experiment steps from allSteps prop
   const experimentSteps = allSteps.map((stepData, index) => ({


### PR DESCRIPTION
This pull request implements HCl equilibrium reaction functionality and updates step navigation behavior in the virtual lab.

Changes made:

**Equipment.tsx:**
- Added HCl detection logic to test tube image rendering
- Implemented blue equilibrium image display when HCl is added to existing cobalt solution
- Restructured conditional logic to check for HCl before stirrer conditions

**ExperimentSteps.tsx:**
- Modified step click behavior to allow clicking on steps 2-7 regardless of completion status
- Updated cursor styling to show pointer for clickable steps (2-7) and default for others

**VirtualLabApp.tsx:**
- Added HCl addition handling with equilibrium color change notification
- Implemented automatic progression to step 3 after HCl equilibrium reaction
- Added toast messages for equilibrium change and automatic step advancement

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 16`

🔗 [Edit in Builder.io](https://builder.io/app/projects/b4a582e1ff9744268b4414bdc38de9ad/zen-nest)

👀 [Preview Link](https://b4a582e1ff9744268b4414bdc38de9ad-zen-nest.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>b4a582e1ff9744268b4414bdc38de9ad</projectId>-->
<!--<branchName>zen-nest</branchName>-->