### PR TITLE
Add step 3 water handling for equilibrium reaction

### DIFF
--- a/client/src/components/VirtualLab/Equipment.tsx
+++ b/client/src/components/VirtualLab/Equipment.tsx
@@ -349,8 +349,12 @@ export const Equipment: React.FC<EquipmentProps> = ({
         // Check if HCl has been added to the test tube
         const hasHCl = chemicals.some((c) => c.id === "hcl_conc");
 
+        // If step 3 water is added, show the user's provided pink image
+        if (cobaltReactionState?.step3WaterAdded) {
+          return "https://cdn.builder.io/api/v1/image/assets%2Fbb47062bd82c4f868e040d020060d188%2Feeb7df22fe61456fba4189a1ac007f37?format=webp&width=800";
+        }
         // If HCl is added to existing solution, show blue equilibrium image
-        if (
+        else if (
           hasHCl &&
           cobaltReactionState?.cobaltChlorideAdded &&
           cobaltReactionState?.distilledWaterAdded

--- a/client/src/components/VirtualLab/Equipment.tsx
+++ b/client/src/components/VirtualLab/Equipment.tsx
@@ -31,6 +31,7 @@ interface EquipmentProps {
     distilledWaterAdded: boolean;
     stirrerActive: boolean;
     colorTransition: "blue" | "transitioning" | "pink";
+    step3WaterAdded: boolean;
   };
 }
 

--- a/client/src/components/VirtualLab/VirtualLabApp.tsx
+++ b/client/src/components/VirtualLab/VirtualLabApp.tsx
@@ -358,7 +358,6 @@ function VirtualLabApp({
     } else if (experimentTitle.includes("Equilibrium")) {
       return [
         { id: "test_tubes", name: "Test Tubes", icon: <TestTube size={36} /> },
-        { id: "dropper", name: "Dropper", icon: <Droplets size={36} /> },
         {
           id: "stirring_rod",
           name: "Stirring Rod",

--- a/client/src/components/VirtualLab/VirtualLabApp.tsx
+++ b/client/src/components/VirtualLab/VirtualLabApp.tsx
@@ -647,9 +647,9 @@ function VirtualLabApp({
                 setToastMessage(null);
                 // Auto-advance to step 3
                 setCurrentStep(3);
-                setToastMessage("Moving to Step 3 automatically...");
+                setToastMessage("Moving to the next step...");
                 setTimeout(() => setToastMessage(null), 3000);
-              }, 8000);
+              }, 2000);
             } else {
               setToastMessage(
                 `Added ${amount}mL of ${chemical.name} to ${equipmentId}`,

--- a/client/src/components/VirtualLab/VirtualLabApp.tsx
+++ b/client/src/components/VirtualLab/VirtualLabApp.tsx
@@ -1076,6 +1076,7 @@ function VirtualLabApp({
                         distilledWaterAdded,
                         stirrerActive,
                         colorTransition,
+                        step3WaterAdded,
                       }}
                     />
                   ) : null;

--- a/client/src/components/VirtualLab/VirtualLabApp.tsx
+++ b/client/src/components/VirtualLab/VirtualLabApp.tsx
@@ -633,8 +633,23 @@ function VirtualLabApp({
               setTimeout(() => setToastMessage(null), 3000);
             } else if (chemicalId === "water" && cobaltChlorideAdded) {
               setDistilledWaterAdded(true);
-              setToastMessage("Add the stirrer");
-              setTimeout(() => setToastMessage(null), 5000);
+
+              // Check if we're in step 3 for the reverse equilibrium reaction
+              if (currentStep === 3) {
+                setStep3WaterAdded(true);
+                setToastMessage(
+                  "Color changing back to pink as the equilibrium shifts in the reverse direction!",
+                );
+                setTimeout(() => {
+                  setToastMessage(null);
+                  // Auto-advance to step 4
+                  setCurrentStep(4);
+                  onStepComplete();
+                }, 3000);
+              } else {
+                setToastMessage("Add the stirrer");
+                setTimeout(() => setToastMessage(null), 5000);
+              }
             } else if (
               chemicalId === "hcl_conc" &&
               cobaltChlorideAdded &&

--- a/client/src/components/VirtualLab/VirtualLabApp.tsx
+++ b/client/src/components/VirtualLab/VirtualLabApp.tsx
@@ -1024,6 +1024,7 @@ function VirtualLabApp({
                     setDistilledWaterAdded(false);
                     setStirrerActive(false);
                     setColorTransition("pink");
+                    setStep3WaterAdded(false);
                   }}
                 />
               </div>

--- a/client/src/components/VirtualLab/VirtualLabApp.tsx
+++ b/client/src/components/VirtualLab/VirtualLabApp.tsx
@@ -103,6 +103,7 @@ function VirtualLabApp({
   const [colorTransition, setColorTransition] = useState<
     "blue" | "transitioning" | "pink"
   >("pink");
+  const [step3WaterAdded, setStep3WaterAdded] = useState(false);
 
   // Use dynamic experiment steps from allSteps prop
   const experimentSteps = allSteps.map((stepData, index) => ({


### PR DESCRIPTION
This change adds support for step 3 water addition in the cobalt equilibrium reaction:

- Added `step3WaterAdded` state variable to track when water is added in step 3
- Modified water addition logic to detect step 3 and show appropriate pink color image
- Updated Equipment component to display user-provided pink image when step3WaterAdded is true
- Changed HCl condition from `if` to `else if` to properly handle the new step 3 logic
- Removed dropper from equipment list for equilibrium experiments
- Added step3WaterAdded to cobaltReactionState interface and reset functionality
- Updated toast messages and timing for step transitions
- Auto-advances to step 4 after step 3 water addition with appropriate feedback message

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 17`

🔗 [Edit in Builder.io](https://builder.io/app/projects/1c56da26c42c402aa40f79b42fc05276/zenith-nest)

👀 [Preview Link](https://1c56da26c42c402aa40f79b42fc05276-zenith-nest.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>1c56da26c42c402aa40f79b42fc05276</projectId>-->
<!--<branchName>zenith-nest</branchName>-->