### PR TITLE
Extend message display times and add current step indicators

### DIFF
--- a/client/src/components/VirtualLab/Equipment.tsx
+++ b/client/src/components/VirtualLab/Equipment.tsx
@@ -547,10 +547,12 @@ export const Equipment: React.FC<EquipmentProps> = ({
           setCoolingStartTime(Date.now());
           setShowCoolingMessage(true);
 
-          // Hide message after 1 second and replace image
+          // Keep cooling message visible and replace image
+          setUseCooledImage(true);
+
+          // Keep cooling message visible for longer, then show exothermic message
           setTimeout(() => {
             setShowCoolingMessage(false);
-            setUseCooledImage(true);
 
             // Remove cold beaker and show exothermic message
             setShouldHideColdBeaker(true);

--- a/client/src/components/VirtualLab/Equipment.tsx
+++ b/client/src/components/VirtualLab/Equipment.tsx
@@ -559,12 +559,12 @@ export const Equipment: React.FC<EquipmentProps> = ({
             setShowExothermicMessage(true);
             console.log("Exothermic message should now be visible");
 
-            // Hide exothermic message after 1 second and show final image
+            // Keep exothermic message visible for longer, then hide and show final image
             setTimeout(() => {
               setShowExothermicMessage(false);
               setUseCooledFinalImage(true);
 
-              // Auto-advance to step 6 after the message
+              // Auto-advance to step 6 after keeping the message visible longer
               if (onRemove && currentStep === 5) {
                 setTimeout(() => {
                   // This will trigger step completion in the parent component
@@ -574,7 +574,7 @@ export const Equipment: React.FC<EquipmentProps> = ({
                   window.dispatchEvent(stepCompleteEvent);
                 }, 500);
               }
-            }, 1000);
+            }, 4000); // Keep exothermic message visible for 4 seconds
 
             // Remove the cold water beaker from equipment list if onRemove is available
             if (onRemove) {

--- a/client/src/components/VirtualLab/Equipment.tsx
+++ b/client/src/components/VirtualLab/Equipment.tsx
@@ -582,7 +582,7 @@ export const Equipment: React.FC<EquipmentProps> = ({
                 onRemove("beaker_cold_water");
               }, 500); // Small delay to show the message first
             }
-          }, 500);
+          }, 3000); // Keep cooling message visible for 3 seconds
         } else if (!cooling && coolingStartTime) {
           // Stopped cooling - reset states
           setCoolingStartTime(null);

--- a/client/src/components/VirtualLab/Equipment.tsx
+++ b/client/src/components/VirtualLab/Equipment.tsx
@@ -503,13 +503,15 @@ export const Equipment: React.FC<EquipmentProps> = ({
             setShowEndothermicMessage(true);
             console.log("Endothermic message should now be visible");
 
-            // Hide endothermic message after 1 second and show final image
-            setTimeout(() => {
-              setShowEndothermicMessage(false);
-              setUseFinalImage(true);
+            // Keep endothermic message visible and show final image
+            setUseFinalImage(true);
 
-              // Auto-advance to step 5 after the message
-              if (onRemove && currentStep === 4) {
+            // Auto-advance to step 5 after keeping the message visible for longer
+            if (onRemove && currentStep === 4) {
+              setTimeout(() => {
+                // Hide the message before advancing
+                setShowEndothermicMessage(false);
+
                 setTimeout(() => {
                   // This will trigger step completion in the parent component
                   const stepCompleteEvent = new CustomEvent("stepComplete", {
@@ -517,8 +519,8 @@ export const Equipment: React.FC<EquipmentProps> = ({
                   });
                   window.dispatchEvent(stepCompleteEvent);
                 }, 500);
-              }
-            }, 1000);
+              }, 4000); // Keep message visible for 4 seconds
+            }
 
             // Remove the hot water beaker from equipment list if onRemove is available
             if (onRemove) {
@@ -705,7 +707,7 @@ export const Equipment: React.FC<EquipmentProps> = ({
 
           {/* Endothermic reaction message */}
           {showEndothermicMessage && (
-            <div className="fixed top-4 left-1/2 transform -translate-x-1/2 bg-blue-500 text-white px-6 py-3 rounded-lg text-lg font-bold animate-bounce shadow-xl whitespace-nowrap z-[9999] border-2 border-white">
+            <div className="fixed top-4 left-1/2 transform -translate-x-1/2 bg-blue-500 text-white px-4 py-2 rounded-lg text-sm font-bold animate-bounce shadow-xl whitespace-nowrap z-[9999] border-2 border-white">
               🧪 Solution became blue again due to Endothermic Reaction! 🧪
             </div>
           )}

--- a/client/src/components/VirtualLab/ExperimentSteps.tsx
+++ b/client/src/components/VirtualLab/ExperimentSteps.tsx
@@ -93,7 +93,7 @@ export const ExperimentSteps: React.FC<ExperimentStepsProps> = ({
                     {getStepIcon(step, index)}
                   </div>
                   <div className="flex-1">
-                    <div className="flex items-center justify-between">
+                    <div className="flex items-center justify-between mb-1">
                       <h3 className="font-medium text-gray-900">
                         Step {step.id}: {step.title}
                       </h3>
@@ -101,6 +101,14 @@ export const ExperimentSteps: React.FC<ExperimentStepsProps> = ({
                         {step.duration}min
                       </span>
                     </div>
+                    {step.status === "active" && (
+                      <div className="mb-2">
+                        <span className="inline-flex items-center px-2 py-1 bg-blue-500 text-white text-xs font-bold rounded-full">
+                          <div className="w-2 h-2 bg-white rounded-full animate-pulse mr-1"></div>
+                          CURRENT STEP
+                        </span>
+                      </div>
+                    )}
                     <p className="text-sm text-gray-600 mt-1">
                       {step.description}
                     </p>

--- a/client/src/components/VirtualLab/VirtualLabApp.tsx
+++ b/client/src/components/VirtualLab/VirtualLabApp.tsx
@@ -76,6 +76,7 @@ interface VirtualLabProps {
   onStartExperiment: () => void;
   isRunning: boolean;
   setIsRunning: (running: boolean) => void;
+  onResetTimer: () => void;
 }
 
 function VirtualLabApp({

--- a/client/src/components/VirtualLab/VirtualLabApp.tsx
+++ b/client/src/components/VirtualLab/VirtualLabApp.tsx
@@ -903,7 +903,7 @@ function VirtualLabApp({
         id: Date.now().toString(),
         type: "reaction",
         title: "Acid-Base Neutralization Detected",
-        description: "HCl + NaOH �� NaCl + H��O",
+        description: "HCl + NaOH → NaCl + H��O",
         timestamp: new Date().toLocaleTimeString(),
         calculation: {
           reaction: "HCl + NaOH → NaCl + H���O",
@@ -1138,10 +1138,16 @@ function VirtualLabApp({
           {/* Equipment Bar - Top Horizontal */}
           <div className="bg-white/90 backdrop-blur-sm border-b border-gray-200 p-3">
             <div className="flex items-center justify-between">
-              <h4 className="font-semibold text-gray-800 text-sm flex items-center">
-                <Atom className="w-4 h-4 mr-2 text-blue-600" />
-                {experimentTitle} - Equipment
-              </h4>
+              <div className="flex items-center space-x-3">
+                <h4 className="font-semibold text-gray-800 text-sm flex items-center">
+                  <Atom className="w-4 h-4 mr-2 text-blue-600" />
+                  {experimentTitle} - Equipment
+                </h4>
+                <span className="inline-flex items-center px-2 py-1 bg-blue-500 text-white text-xs font-bold rounded-full">
+                  <div className="w-1.5 h-1.5 bg-white rounded-full animate-pulse mr-1"></div>
+                  STEP {currentStep}
+                </span>
+              </div>
               <div className="flex items-center space-x-2">
                 {experimentTitle.includes("Aspirin") ? (
                   <div className="text-xs text-gray-600 mr-3 flex items-center space-x-2">

--- a/client/src/components/VirtualLab/VirtualLabApp.tsx
+++ b/client/src/components/VirtualLab/VirtualLabApp.tsx
@@ -91,6 +91,7 @@ function VirtualLabApp({
   onStartExperiment,
   isRunning,
   setIsRunning,
+  onResetTimer,
 }: VirtualLabProps) {
   const [equipmentPositions, setEquipmentPositions] = useState<
     EquipmentPosition[]

--- a/client/src/components/VirtualLab/VirtualLabApp.tsx
+++ b/client/src/components/VirtualLab/VirtualLabApp.tsx
@@ -903,7 +903,7 @@ function VirtualLabApp({
         id: Date.now().toString(),
         type: "reaction",
         title: "Acid-Base Neutralization Detected",
-        description: "HCl + NaOH → NaCl + H��O",
+        description: "HCl + NaOH �� NaCl + H��O",
         timestamp: new Date().toLocaleTimeString(),
         calculation: {
           reaction: "HCl + NaOH → NaCl + H���O",
@@ -1000,10 +1000,11 @@ function VirtualLabApp({
                         </p>
 
                         {currentGuidedStep === step.id && (
-                          <div className="mt-2 ml-8 p-2 bg-yellow-100 border border-yellow-300 rounded text-xs">
-                            <span className="font-medium text-yellow-800">
-                              👆 Current step
-                            </span>
+                          <div className="mt-2 ml-8 flex items-center gap-2">
+                            <div className="px-2 py-1 bg-blue-500 text-white text-xs font-bold rounded-full flex items-center gap-1">
+                              <div className="w-2 h-2 bg-white rounded-full animate-pulse"></div>
+                              CURRENT STEP
+                            </div>
                           </div>
                         )}
                       </div>

--- a/client/src/components/VirtualLab/VirtualLabApp.tsx
+++ b/client/src/components/VirtualLab/VirtualLabApp.tsx
@@ -176,9 +176,12 @@ function VirtualLabApp({
     setShowCompletionModal(true);
   };
 
+  const [, setLocation] = useLocation();
+
   const handleCompletionClose = () => {
     setShowCompletionModal(false);
-    // Optionally navigate back to experiments list
+    // Navigate back to experiments list (home page)
+    setLocation("/");
   };
 
   // Use dynamic experiment steps from allSteps prop

--- a/client/src/components/VirtualLab/VirtualLabApp.tsx
+++ b/client/src/components/VirtualLab/VirtualLabApp.tsx
@@ -1195,6 +1195,7 @@ function VirtualLabApp({
                     setStirrerActive(false);
                     setColorTransition("pink");
                     setStep3WaterAdded(false);
+                    onResetTimer();
                   }}
                 />
               </div>

--- a/client/src/components/VirtualLab/VirtualLabApp.tsx
+++ b/client/src/components/VirtualLab/VirtualLabApp.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useCallback, useMemo, useEffect } from "react";
+import { useLocation } from "wouter";
 import { Equipment } from "./Equipment";
 import { WorkBench } from "./WorkBench";
 import { Chemical } from "./Chemical";

--- a/client/src/pages/experiment.tsx
+++ b/client/src/pages/experiment.tsx
@@ -254,9 +254,15 @@ export default function Experiment() {
                     >
                       <ArrowLeft className="h-4 w-4" />
                     </Button>
-                    <span className="text-sm text-gray-600 px-2">
-                      {currentStep + 1} / {experiment.stepDetails.length}
-                    </span>
+                    <div className="flex items-center space-x-2 px-2">
+                      <span className="text-sm text-gray-600">
+                        {currentStep + 1} / {experiment.stepDetails.length}
+                      </span>
+                      <span className="inline-flex items-center px-2 py-1 bg-blue-500 text-white text-xs font-bold rounded-full">
+                        <div className="w-1.5 h-1.5 bg-white rounded-full animate-pulse mr-1"></div>
+                        STEP {currentStep + 1}
+                      </span>
+                    </div>
                     <Button
                       variant="outline"
                       onClick={handleNextStep}

--- a/client/src/pages/experiment.tsx
+++ b/client/src/pages/experiment.tsx
@@ -291,6 +291,7 @@ export default function Experiment() {
                 onStartExperiment={handleStartExperiment}
                 isRunning={isRunning}
                 setIsRunning={setIsRunning}
+                onResetTimer={() => setTimer(0)}
               />
             </CardContent>
           </Card>


### PR DESCRIPTION
This pull request makes the following changes to the virtual lab interface:

**Message Display Timing:**
- Extended endothermic message display from 1 second to 4 seconds
- Extended exothermic message display from 1 second to 4 seconds  
- Extended cooling message display from 500ms to 3 seconds
- Restructured timeout logic to show final images immediately while keeping messages visible longer

**Visual Improvements:**
- Added "CURRENT STEP" indicators with animated pulse dots throughout the interface
- Updated endothermic message styling to use smaller padding and text size
- Added current step indicator to equipment bar header
- Enhanced step navigation with current step badges

**Navigation Enhancement:**
- Added automatic navigation back to home page when experiment completion modal is closed
- Added timer reset functionality when experiment is reset

**Code Structure:**
- Reorganized setTimeout chains for better readability and timing control
- Added onResetTimer prop to VirtualLabApp component

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 27`

🔗 [Edit in Builder.io](https://builder.io/app/projects/83cdcb7d394d489e94b56477a4ca5606/vortex-nest)

👀 [Preview Link](https://83cdcb7d394d489e94b56477a4ca5606-vortex-nest.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>83cdcb7d394d489e94b56477a4ca5606</projectId>-->
<!--<branchName>vortex-nest</branchName>-->