### PR TITLE
Stop timer on results view and remove aspirin safety guide

### DIFF
--- a/client/src/components/safety-guide-modal.tsx
+++ b/client/src/components/safety-guide-modal.tsx
@@ -54,17 +54,13 @@ export default function SafetyGuideModal({ children }: SafetyGuideModalProps) {
                 <Droplets className="h-5 w-5 text-blue-600" />
                 Chemical Handling
               </h3>
-              <div className="space-y-3">
-                <div className="bg-yellow-50 p-3 rounded-lg border-l-4 border-yellow-400">
-                  <h4 className="font-medium text-yellow-800">Aspirin Synthesis Safety</h4>
-                  <ul className="text-sm text-yellow-700 mt-2 space-y-1">
-                    <li>• Salicylic acid: Handle with care, avoid skin contact</li>
-                    <li>• Acetic anhydride: Corrosive, keep away from water</li>
-                    <li>• Sulfuric acid: Strong acid, extremely corrosive</li>
-                    <li>• Always add chemicals in the specified order</li>
-                  </ul>
-                </div>
-              </div>
+              <ul className="space-y-2 text-sm">
+                <li>• Clearly label all reagents and verify concentrations before use</li>
+                <li>• Add acid to water when diluting, never the reverse</li>
+                <li>• Do not mix unknown chemicals or exceed specified volumes</li>
+                <li>• Treat corrosive and oxidizing reagents with extra care</li>
+                <li>• Clean simulated spills immediately and reset if unsafe conditions occur</li>
+              </ul>
             </section>
 
             {/* Temperature Control */}

--- a/client/src/experiments/EquilibriumShift/components/VirtualLab.tsx
+++ b/client/src/experiments/EquilibriumShift/components/VirtualLab.tsx
@@ -70,6 +70,13 @@ export default function VirtualLab({
   const [isStirring, setIsStirring] = useState<boolean>(false);
   const [stirAnimationStep, setStirAnimationStep] = useState<number>(0);
 
+  // Stop the timer when the results & analysis modal appears
+  useEffect(() => {
+    if (showResultsModal) {
+      setIsRunning(false);
+    }
+  }, [showResultsModal, setIsRunning]);
+
   // Handle color transitions with animation
   const animateColorTransition = useCallback((fromColor: string, toColor: string, newState: EquilibriumState) => {
     setColorTransition({

--- a/client/src/experiments/FeSCNEquilibrium/components/VirtualLab.tsx
+++ b/client/src/experiments/FeSCNEquilibrium/components/VirtualLab.tsx
@@ -63,6 +63,13 @@ export default function VirtualLab({
   const [equipmentPositions, setEquipmentPositions] = useState<LabEquipment[]>([]);
   const [draggingSolution, setDraggingSolution] = useState<{ id: string; volume: number } | null>(null);
 
+  // Stop timer once the analysis panel is visible
+  useEffect(() => {
+    if (showAnalysis) {
+      setIsRunning(false);
+    }
+  }, [showAnalysis, setIsRunning]);
+
   // Initialize test tubes when experiment starts
   useEffect(() => {
     if (experimentStarted && testTubes.length === 0) {


### PR DESCRIPTION
## Purpose

Based on user feedback, this PR addresses two specific improvements:
1. **Timer behavior**: Stop the experiment timer automatically when users reach the results and analysis page to provide accurate timing measurements
2. **Safety guide cleanup**: Remove the aspirin synthesis safety section from the general safety guide modal to streamline the content

## Code changes

### Timer Management
- Added `useEffect` hooks in both `EquilibriumShift/VirtualLab.tsx` and `FeSCNEquilibrium/VirtualLab.tsx` to automatically stop the timer when results/analysis modals appear
- Timer stops when `showResultsModal` or `showAnalysis` state becomes true

### Safety Guide Updates  
- Removed the aspirin synthesis safety section from `safety-guide-modal.tsx`
- Replaced specific aspirin handling guidelines with general chemical handling best practices
- Simplified the Chemical Handling section to focus on universal lab safety principles

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 39`

🔗 [Edit in Builder.io](https://builder.io/app/projects/ada7a876c74742d9a4eadb949781690a/cosmos-hub)

👀 [Preview Link](https://ada7a876c74742d9a4eadb949781690a-cosmos-hub.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>ada7a876c74742d9a4eadb949781690a</projectId>-->
<!--<branchName>cosmos-hub</branchName>-->