### PR TITLE
Add workbench-style preparation flow for Lassaigne test

### DIFF
--- a/client/src/experiments/LassaigneTest/components/VirtualLab.tsx
+++ b/client/src/experiments/LassaigneTest/components/VirtualLab.tsx
@@ -254,84 +254,108 @@ export default function VirtualLab({
       )}
 
       {showPrepWorkbench && !hasExtract ? (
-        <div className="grid grid-cols-1 lg:grid-cols-12 gap-6 relative z-0">
-          {/* Equipment - Left */}
-          <div className="lg:col-span-3 space-y-4">
-            <div className="bg-white/90 backdrop-blur-sm rounded-xl p-4 border border-gray-200 shadow-sm">
-              <h3 className="text-lg font-semibold text-gray-800 mb-4 flex items-center">
-                <Wrench className="w-5 h-5 mr-2 text-blue-600" />
-                Equipment
-              </h3>
-
-              <div className="space-y-3">
-                <div className="flex flex-col items-center p-4 rounded-lg border-2 border-gray-300 bg-white hover:border-blue-400 hover:shadow-lg transition-all">
-                  <TestTube className="w-8 h-8 text-blue-600 mb-2" />
-                  <span className="text-sm font-medium text-gray-700 text-center">Ignition Tube</span>
-                </div>
-                <div className="flex flex-col items-center p-4 rounded-lg border-2 border-gray-300 bg-white hover:border-blue-400 hover:shadow-lg transition-all">
-                  <Beaker className="w-8 h-8 text-emerald-600 mb-2" />
-                  <span className="text-sm font-medium text-gray-700 text-center">Sodium Piece (under kerosene)</span>
-                </div>
-                <div className="flex flex-col items-center p-4 rounded-lg border-2 border-gray-300 bg-white hover:border-blue-400 hover:shadow-lg transition-all">
-                  <FlaskConical className="w-8 h-8 text-purple-600 mb-2" />
-                  <span className="text-sm font-medium text-gray-700 text-center">Organic Compound</span>
-                </div>
-                <div className="flex flex-col items-center p-4 rounded-lg border-2 border-gray-300 bg-white hover:border-blue-400 hover:shadow-lg transition-all">
-                  <Droplets className="w-8 h-8 text-blue-500 mb-2" />
-                  <span className="text-sm font-medium text-gray-700 text-center">Water Bath</span>
-                </div>
-                <div className="flex flex-col items-center p-4 rounded-lg border-2 border-gray-300 bg-white hover:border-blue-400 hover:shadow-lg transition-all">
-                  <Filter className="w-8 h-8 text-amber-600 mb-2" />
-                  <span className="text-sm font-medium text-gray-700 text-center">Filter Paper & Funnel</span>
-                </div>
+        <>
+          <div className="mb-6 bg-white/90 backdrop-blur-sm rounded-xl p-4 border border-blue-200 shadow-sm">
+            <div className="flex items-center justify-between mb-3">
+              <h3 className="text-lg font-semibold text-gray-800">Preparation Progress</h3>
+              <span className="text-sm text-blue-600 font-medium">Step {prepStep + 1} of {preparationSteps.length}</span>
+            </div>
+            <div className="flex items-start space-x-3">
+              <div className="w-8 h-8 rounded-full bg-blue-500 text-white flex items-center justify-center text-sm font-bold">{prepStep + 1}</div>
+              <div className="flex-1">
+                <h4 className="font-semibold text-gray-800 mb-1">{preparationSteps[prepStep].title}</h4>
+                <p className="text-sm text-gray-600 mb-2">{preparationSteps[prepStep].detail}</p>
+                <div className="inline-flex items-center px-3 py-1 bg-blue-100 text-blue-700 rounded-full text-xs font-medium">Follow the step on the workbench</div>
               </div>
-
-              <div className="mt-4 p-3 bg-blue-50 rounded-lg text-xs text-blue-700">
-                Drag-and-drop not required here; follow the guided steps on the workbench.
+              <div className="flex items-center gap-2">
+                {prepStep < preparationSteps.length - 1 ? (
+                  <Button onClick={() => setPrepStep((s) => s + 1)} className="bg-blue-600 hover:bg-blue-700 text-white">Next</Button>
+                ) : (
+                  <Button onClick={finishPreparation} className="bg-emerald-600 hover:bg-emerald-700 text-white">Finish</Button>
+                )}
               </div>
             </div>
           </div>
 
-          {/* Workbench - Center */}
-          <div className="lg:col-span-6">
-            <WorkBench
-              step={prepStep}
-              totalSteps={preparationSteps.length}
-              title={preparationSteps[prepStep].title}
-              detail={preparationSteps[prepStep].detail}
-              onNext={() => setPrepStep((s) => Math.min(s + 1, preparationSteps.length - 1))}
-              onFinish={finishPreparation}
-            />
-          </div>
+          <div className="grid grid-cols-1 lg:grid-cols-12 gap-6 relative z-0">
+            {/* Equipment - Left */}
+            <div className="lg:col-span-3 space-y-4">
+              <div className="bg-white/90 backdrop-blur-sm rounded-xl p-4 border border-gray-200 shadow-sm">
+                <h3 className="text-lg font-semibold text-gray-800 mb-4 flex items-center">
+                  <Wrench className="w-5 h-5 mr-2 text-blue-600" />
+                  Equipment
+                </h3>
 
-          {/* Analysis - Right */}
-          <div className="lg:col-span-3 space-y-4">
-            <div className="bg-white/90 backdrop-blur-sm rounded-xl p-4 border border-gray-200 shadow-sm">
-              <h3 className="text-lg font-semibold text-gray-800 mb-4 flex items-center">
-                <Info className="w-5 h-5 mr-2 text-green-600" />
-                Live Analysis
-              </h3>
-              <div className="mb-4">
-                <h4 className="font-semibold text-sm text-gray-700 mb-2">Current State</h4>
-                <p className="text-xs text-gray-600">Preparing Lassaigne's extract (Step {prepStep + 1} of {preparationSteps.length}).</p>
-              </div>
-              <div>
-                <h4 className="font-semibold text-sm text-gray-700 mb-2">Completed Steps</h4>
-                <div className="space-y-1">
-                  {preparationSteps.map((s, idx) => (
-                    <div key={idx} className={`flex items-center space-x-2 text-xs ${idx <= prepStep ? 'text-green-600' : 'text-gray-400'}`}>
-                      <CheckCircle className="w-3 h-3" />
-                      <span>{s.title}</span>
-                    </div>
-                  ))}
+                <div className="space-y-3">
+                  <div className="flex flex-col items-center p-4 rounded-lg border-2 border-gray-300 bg-white hover:border-blue-400 hover:shadow-lg transition-all">
+                    <TestTube className="w-8 h-8 text-blue-600 mb-2" />
+                    <span className="text-sm font-medium text-gray-700 text-center">Ignition Tube</span>
+                  </div>
+                  <div className="flex flex-col items-center p-4 rounded-lg border-2 border-gray-300 bg-white hover:border-blue-400 hover:shadow-lg transition-all">
+                    <Beaker className="w-8 h-8 text-emerald-600 mb-2" />
+                    <span className="text-sm font-medium text-gray-700 text-center">Sodium Piece (under kerosene)</span>
+                  </div>
+                  <div className="flex flex-col items-center p-4 rounded-lg border-2 border-gray-300 bg-white hover:border-blue-400 hover:shadow-lg transition-all">
+                    <FlaskConical className="w-8 h-8 text-purple-600 mb-2" />
+                    <span className="text-sm font-medium text-gray-700 text-center">Organic Compound</span>
+                  </div>
+                  <div className="flex flex-col items-center p-4 rounded-lg border-2 border-gray-300 bg-white hover:border-blue-400 hover:shadow-lg transition-all">
+                    <Droplets className="w-8 h-8 text-blue-500 mb-2" />
+                    <span className="text-sm font-medium text-gray-700 text-center">Water Bath</span>
+                  </div>
+                  <div className="flex flex-col items-center p-4 rounded-lg border-2 border-gray-300 bg-white hover:border-blue-400 hover:shadow-lg transition-all">
+                    <Filter className="w-8 h-8 text-amber-600 mb-2" />
+                    <span className="text-sm font-medium text-gray-700 text-center">Filter Paper & Funnel</span>
+                  </div>
+                </div>
+
+                <div className="mt-4 p-3 bg-blue-50 rounded-lg text-xs text-blue-700">
+                  Drag-and-drop not required here; follow the guided steps on the workbench.
                 </div>
               </div>
-              <div className="mt-4 p-3 bg-yellow-50 rounded-lg text-xs text-yellow-800">
-                Safety: Handle sodium under kerosene; use a shield when heating.
+            </div>
+
+            {/* Workbench - Center */}
+            <div className="lg:col-span-6">
+              <WorkBench
+                step={prepStep}
+                totalSteps={preparationSteps.length}
+                title={preparationSteps[prepStep].title}
+                detail={preparationSteps[prepStep].detail}
+                onNext={() => setPrepStep((s) => Math.min(s + 1, preparationSteps.length - 1))}
+                onFinish={finishPreparation}
+              />
+            </div>
+
+            {/* Analysis - Right */}
+            <div className="lg:col-span-3 space-y-4">
+              <div className="bg-white/90 backdrop-blur-sm rounded-xl p-4 border border-gray-200 shadow-sm">
+                <h3 className="text-lg font-semibold text-gray-800 mb-4 flex items-center">
+                  <Info className="w-5 h-5 mr-2 text-green-600" />
+                  Live Analysis
+                </h3>
+                <div className="mb-4">
+                  <h4 className="font-semibold text-sm text-gray-700 mb-2">Current State</h4>
+                  <p className="text-xs text-gray-600">Preparing Lassaigne's extract (Step {prepStep + 1} of {preparationSteps.length}).</p>
+                </div>
+                <div>
+                  <h4 className="font-semibold text-sm text-gray-700 mb-2">Completed Steps</h4>
+                  <div className="space-y-1">
+                    {preparationSteps.map((s, idx) => (
+                      <div key={idx} className={`flex items-center space-x-2 text-xs ${idx <= prepStep ? 'text-green-600' : 'text-gray-400'}`}>
+                        <CheckCircle className="w-3 h-3" />
+                        <span>{s.title}</span>
+                      </div>
+                    ))}
+                  </div>
+                </div>
+                <div className="mt-4 p-3 bg-yellow-50 rounded-lg text-xs text-yellow-800">
+                  Safety: Handle sodium under kerosene; use a shield when heating.
+                </div>
               </div>
             </div>
           </div>
-        </div>
+        </>
       ) : (
         <div className="grid grid-cols-1 lg:grid-cols-2 gap-6 relative z-0">
           {actions.filter(a => hasExtract ? a.id !== 1 : true).map((action) => (

--- a/client/src/experiments/LassaigneTest/components/VirtualLab.tsx
+++ b/client/src/experiments/LassaigneTest/components/VirtualLab.tsx
@@ -1,7 +1,7 @@
 import React, { useMemo, useState } from "react";
 import { Card, CardContent } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
-import { CheckCircle, Beaker, FlaskConical, Droplets, Sparkles, Eraser, Play, Wrench, Info } from "lucide-react";
+import { CheckCircle, Beaker, FlaskConical, Droplets, Sparkles, Eraser, Play, Wrench, Info, TestTube } from "lucide-react";
 import type { ExperimentMode } from "../types";
 import WorkBench from "./WorkBench";
 
@@ -166,7 +166,7 @@ export default function VirtualLab({
       stepId: 8,
       title: "Halogen Test (AgNO₃)",
       icon: <Sparkles className="w-5 h-5" />,
-      description: "After HNO₃ treatment, add AgNO₃ to observe halide precipitate.",
+      description: "After HNO₃ treatment, add AgNO��� to observe halide precipitate.",
       canRun: hasExtract && interferenceRemoved && halide == null,
       run: () => {
         const halides: Array<"Cl" | "Br" | "I"> = ["Cl", "Br", "I"];

--- a/client/src/experiments/LassaigneTest/components/VirtualLab.tsx
+++ b/client/src/experiments/LassaigneTest/components/VirtualLab.tsx
@@ -1,8 +1,9 @@
 import React, { useMemo, useState } from "react";
 import { Card, CardContent } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
-import { CheckCircle, Beaker, FlaskConical, Droplets, TestTube, ShieldAlert, Sparkles, Eraser, Play } from "lucide-react";
+import { CheckCircle, Beaker, FlaskConical, Droplets, Sparkles, Eraser, Play, Wrench, Info } from "lucide-react";
 import type { ExperimentMode } from "../types";
+import WorkBench from "./WorkBench";
 
 interface VirtualLabProps {
   experimentStarted: boolean;

--- a/client/src/experiments/LassaigneTest/components/VirtualLab.tsx
+++ b/client/src/experiments/LassaigneTest/components/VirtualLab.tsx
@@ -262,13 +262,30 @@ export default function VirtualLab({
                 <Wrench className="w-5 h-5 mr-2 text-blue-600" />
                 Equipment
               </h3>
-              <ul className="text-sm text-gray-700 space-y-2">
-                <li>Ignition Tube</li>
-                <li>Sodium Piece (under kerosene)</li>
-                <li>Organic Compound</li>
-                <li>Water Bath</li>
-                <li>Filter Paper & Funnel</li>
-              </ul>
+
+              <div className="space-y-3">
+                <div className="flex flex-col items-center p-4 rounded-lg border-2 border-gray-300 bg-white hover:border-blue-400 hover:shadow-lg transition-all">
+                  <TestTube className="w-8 h-8 text-blue-600 mb-2" />
+                  <span className="text-sm font-medium text-gray-700 text-center">Ignition Tube</span>
+                </div>
+                <div className="flex flex-col items-center p-4 rounded-lg border-2 border-gray-300 bg-white hover:border-blue-400 hover:shadow-lg transition-all">
+                  <Beaker className="w-8 h-8 text-emerald-600 mb-2" />
+                  <span className="text-sm font-medium text-gray-700 text-center">Sodium Piece (under kerosene)</span>
+                </div>
+                <div className="flex flex-col items-center p-4 rounded-lg border-2 border-gray-300 bg-white hover:border-blue-400 hover:shadow-lg transition-all">
+                  <FlaskConical className="w-8 h-8 text-purple-600 mb-2" />
+                  <span className="text-sm font-medium text-gray-700 text-center">Organic Compound</span>
+                </div>
+                <div className="flex flex-col items-center p-4 rounded-lg border-2 border-gray-300 bg-white hover:border-blue-400 hover:shadow-lg transition-all">
+                  <Droplets className="w-8 h-8 text-blue-500 mb-2" />
+                  <span className="text-sm font-medium text-gray-700 text-center">Water Bath</span>
+                </div>
+                <div className="flex flex-col items-center p-4 rounded-lg border-2 border-gray-300 bg-white hover:border-blue-400 hover:shadow-lg transition-all">
+                  <Filter className="w-8 h-8 text-amber-600 mb-2" />
+                  <span className="text-sm font-medium text-gray-700 text-center">Filter Paper & Funnel</span>
+                </div>
+              </div>
+
               <div className="mt-4 p-3 bg-blue-50 rounded-lg text-xs text-blue-700">
                 Drag-and-drop not required here; follow the guided steps on the workbench.
               </div>

--- a/client/src/experiments/LassaigneTest/components/VirtualLab.tsx
+++ b/client/src/experiments/LassaigneTest/components/VirtualLab.tsx
@@ -253,35 +253,99 @@ export default function VirtualLab({
         </div>
       )}
 
-      <div className="grid grid-cols-1 lg:grid-cols-2 gap-6 relative z-0">
-        {actions.map((action) => (
-          <Card key={action.id} className={`transition-all ${currentGuidedStep + 1 === action.id ? 'ring-2 ring-blue-400' : ''}`}>
-            <CardContent className="p-5">
-              <div className="flex items-center gap-3 mb-2">
-                <div className="w-9 h-9 rounded-full bg-blue-50 text-blue-600 flex items-center justify-center">{action.icon}</div>
-                <h4 className="font-semibold text-gray-900">{action.title}</h4>
+      {showPrepWorkbench && !hasExtract ? (
+        <div className="grid grid-cols-1 lg:grid-cols-12 gap-6 relative z-0">
+          {/* Equipment - Left */}
+          <div className="lg:col-span-3 space-y-4">
+            <div className="bg-white/90 backdrop-blur-sm rounded-xl p-4 border border-gray-200 shadow-sm">
+              <h3 className="text-lg font-semibold text-gray-800 mb-4 flex items-center">
+                <Wrench className="w-5 h-5 mr-2 text-blue-600" />
+                Equipment
+              </h3>
+              <ul className="text-sm text-gray-700 space-y-2">
+                <li>Ignition Tube</li>
+                <li>Sodium Piece (under kerosene)</li>
+                <li>Organic Compound</li>
+                <li>Water Bath</li>
+                <li>Filter Paper & Funnel</li>
+              </ul>
+              <div className="mt-4 p-3 bg-blue-50 rounded-lg text-xs text-blue-700">
+                Drag-and-drop not required here; follow the guided steps on the workbench.
               </div>
-              <p className="text-sm text-gray-600 mb-4">{action.description}</p>
+            </div>
+          </div>
 
-              <div className="flex items-center gap-3">
-                <Button size="sm" onClick={action.run} disabled={!action.canRun || !experimentStarted}>
-                  start experiment
-                </Button>
-                {action.id !== 1 && (
-                  <Button size="sm" variant="secondary" onClick={() => onStepComplete(action.stepId)} disabled={!experimentStarted}>
-                    Skip
-                  </Button>
-                )}
-                {action.observation && (
-                  <div className="flex items-center text-green-700 bg-green-50 px-3 py-1 rounded-md text-sm">
-                    <CheckCircle className="w-4 h-4 mr-1" /> {action.observation}
-                  </div>
-                )}
+          {/* Workbench - Center */}
+          <div className="lg:col-span-6">
+            <WorkBench
+              step={prepStep}
+              totalSteps={preparationSteps.length}
+              title={preparationSteps[prepStep].title}
+              detail={preparationSteps[prepStep].detail}
+              onNext={() => setPrepStep((s) => Math.min(s + 1, preparationSteps.length - 1))}
+              onFinish={finishPreparation}
+            />
+          </div>
+
+          {/* Analysis - Right */}
+          <div className="lg:col-span-3 space-y-4">
+            <div className="bg-white/90 backdrop-blur-sm rounded-xl p-4 border border-gray-200 shadow-sm">
+              <h3 className="text-lg font-semibold text-gray-800 mb-4 flex items-center">
+                <Info className="w-5 h-5 mr-2 text-green-600" />
+                Live Analysis
+              </h3>
+              <div className="mb-4">
+                <h4 className="font-semibold text-sm text-gray-700 mb-2">Current State</h4>
+                <p className="text-xs text-gray-600">Preparing Lassaigne's extract (Step {prepStep + 1} of {preparationSteps.length}).</p>
               </div>
-            </CardContent>
-          </Card>
-        ))}
-      </div>
+              <div>
+                <h4 className="font-semibold text-sm text-gray-700 mb-2">Completed Steps</h4>
+                <div className="space-y-1">
+                  {preparationSteps.map((s, idx) => (
+                    <div key={idx} className={`flex items-center space-x-2 text-xs ${idx <= prepStep ? 'text-green-600' : 'text-gray-400'}`}>
+                      <CheckCircle className="w-3 h-3" />
+                      <span>{s.title}</span>
+                    </div>
+                  ))}
+                </div>
+              </div>
+              <div className="mt-4 p-3 bg-yellow-50 rounded-lg text-xs text-yellow-800">
+                Safety: Handle sodium under kerosene; use a shield when heating.
+              </div>
+            </div>
+          </div>
+        </div>
+      ) : (
+        <div className="grid grid-cols-1 lg:grid-cols-2 gap-6 relative z-0">
+          {actions.filter(a => hasExtract ? a.id !== 1 : true).map((action) => (
+            <Card key={action.id} className={`transition-all ${currentGuidedStep + 1 === action.id ? 'ring-2 ring-blue-400' : ''}`}>
+              <CardContent className="p-5">
+                <div className="flex items-center gap-3 mb-2">
+                  <div className="w-9 h-9 rounded-full bg-blue-50 text-blue-600 flex items-center justify-center">{action.icon}</div>
+                  <h4 className="font-semibold text-gray-900">{action.title}</h4>
+                </div>
+                <p className="text-sm text-gray-600 mb-4">{action.description}</p>
+
+                <div className="flex items-center gap-3">
+                  <Button size="sm" onClick={action.run} disabled={!action.canRun || !experimentStarted}>
+                    start experiment
+                  </Button>
+                  {action.id !== 1 && (
+                    <Button size="sm" variant="secondary" onClick={() => onStepComplete(action.stepId)} disabled={!experimentStarted}>
+                      Skip
+                    </Button>
+                  )}
+                  {action.observation && (
+                    <div className="flex items-center text-green-700 bg-green-50 px-3 py-1 rounded-md text-sm">
+                      <CheckCircle className="w-4 h-4 mr-1" /> {action.observation}
+                    </div>
+                  )}
+                </div>
+              </CardContent>
+            </Card>
+          ))}
+        </div>
+      )}
     </div>
   );
 }

--- a/client/src/experiments/LassaigneTest/components/VirtualLab.tsx
+++ b/client/src/experiments/LassaigneTest/components/VirtualLab.tsx
@@ -38,6 +38,7 @@ export default function VirtualLab({
   const [showPreparation, setShowPreparation] = useState(false);
   const [prepStarted, setPrepStarted] = useState(false);
   const [prepStep, setPrepStep] = useState(0);
+  const [showPrepWorkbench, setShowPrepWorkbench] = useState(false);
 
   const preparationSteps = [
     {

--- a/client/src/experiments/LassaigneTest/components/VirtualLab.tsx
+++ b/client/src/experiments/LassaigneTest/components/VirtualLab.tsx
@@ -1,7 +1,7 @@
 import React, { useMemo, useState } from "react";
 import { Card, CardContent } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
-import { CheckCircle, Beaker, FlaskConical, Droplets, Sparkles, Eraser, Play, Wrench, Info, TestTube } from "lucide-react";
+import { CheckCircle, Beaker, FlaskConical, Droplets, Sparkles, Eraser, Play, Wrench, Info, TestTube, Filter } from "lucide-react";
 import type { ExperimentMode } from "../types";
 import WorkBench from "./WorkBench";
 

--- a/client/src/experiments/LassaigneTest/components/VirtualLab.tsx
+++ b/client/src/experiments/LassaigneTest/components/VirtualLab.tsx
@@ -64,14 +64,18 @@ export default function VirtualLab({
   ];
 
   const startPreparation = () => {
+    // Open workbench-style preparation flow
     setPrepStarted(true);
     setPrepStep(0);
+    setShowPreparation(false);
+    setShowPrepWorkbench(true);
   };
 
   const finishPreparation = () => {
     setHasExtract(true);
     onStepComplete(1);
     setShowPreparation(false);
+    setShowPrepWorkbench(false);
     setPrepStarted(false);
   };
 
@@ -80,6 +84,7 @@ export default function VirtualLab({
     setHasExtract(true);
     onStepComplete(1);
     setShowPreparation(false);
+    setShowPrepWorkbench(false);
     setPrepStarted(false);
   };
 

--- a/client/src/experiments/LassaigneTest/components/WorkBench.tsx
+++ b/client/src/experiments/LassaigneTest/components/WorkBench.tsx
@@ -1,0 +1,76 @@
+import React from "react";
+
+interface PrepWorkbenchProps {
+  step: number;
+  totalSteps: number;
+  title: string;
+  detail: string;
+  onNext: () => void;
+  onFinish: () => void;
+}
+
+export default function WorkBench({ step, totalSteps, title, detail, onNext, onFinish }: PrepWorkbenchProps) {
+  const isLast = step + 1 >= totalSteps;
+  return (
+    <div
+      className="relative w-full h-full min-h-[500px] bg-gradient-to-br from-gray-50 to-blue-50 rounded-lg overflow-hidden transition-all duration-300 border-2 border-dashed border-gray-300"
+      style={{
+        backgroundImage: `
+          linear-gradient(135deg, #f8fafc 0%, #e2e8f0 100%),
+          radial-gradient(circle at 25% 25%, rgba(59, 130, 246, 0.1) 0%, transparent 25%),
+          radial-gradient(circle at 75% 75%, rgba(147, 51, 234, 0.1) 0%, transparent 25%)
+        `,
+      }}
+    >
+      <div
+        className="absolute inset-0 opacity-10"
+        style={{
+          backgroundImage: `
+            linear-gradient(45deg, #e2e8f0 25%, transparent 25%),
+            linear-gradient(-45deg, #e2e8f0 25%, transparent 25%),
+            linear-gradient(45deg, transparent 75%, #e2e8f0 75%),
+            linear-gradient(-45deg, transparent 75%, #e2e8f0 75%)
+          `,
+          backgroundSize: "20px 20px",
+          backgroundPosition: "0 0, 0 10px, 10px -10px, -10px 0px",
+        }}
+      />
+
+      <div className="absolute top-4 left-4 bg-white/90 backdrop-blur-sm rounded-lg px-3 py-2 shadow-md border border-gray-200">
+        <div className="flex items-center space-x-2">
+          <div className="w-3 h-3 bg-blue-500 rounded-full animate-pulse" />
+          <span className="text-sm font-medium text-gray-700">Step {step + 1} of {totalSteps}</span>
+        </div>
+      </div>
+
+      <div className="absolute top-4 right-4 bg-white/90 backdrop-blur-sm rounded-lg px-3 py-2 shadow-md border border-gray-200">
+        <span className="text-sm font-medium text-gray-700">Laboratory Workbench</span>
+      </div>
+
+      <div className="absolute inset-0 p-8 flex items-center justify-center">
+        <div className="bg-white/90 rounded-xl shadow-xl border border-gray-200 p-8 max-w-2xl w-full">
+          <h3 className="text-xl font-semibold text-gray-900 mb-2">{title}</h3>
+          <p className="text-gray-700 mb-6">{detail}</p>
+          <div className="flex items-center justify-end gap-3">
+            {!isLast ? (
+              <button onClick={onNext} className="px-4 py-2 rounded-md bg-blue-600 hover:bg-blue-700 text-white text-sm font-medium">Next</button>
+            ) : (
+              <button onClick={onFinish} className="px-4 py-2 rounded-md bg-emerald-600 hover:bg-emerald-700 text-white text-sm font-medium">Finish & Use Extract</button>
+            )}
+          </div>
+        </div>
+      </div>
+
+      <div
+        className="absolute inset-0 opacity-5 pointer-events-none"
+        style={{
+          backgroundImage: `
+            linear-gradient(rgba(59, 130, 246, 0.3) 1px, transparent 1px),
+            linear-gradient(90deg, rgba(59, 130, 246, 0.3) 1px, transparent 1px)
+          `,
+          backgroundSize: "50px 50px",
+        }}
+      />
+    </div>
+  );
+}

--- a/client/src/experiments/LassaigneTest/components/WorkBench.tsx
+++ b/client/src/experiments/LassaigneTest/components/WorkBench.tsx
@@ -9,8 +9,7 @@ interface PrepWorkbenchProps {
   onFinish: () => void;
 }
 
-export default function WorkBench({ step, totalSteps, title, detail, onNext, onFinish }: PrepWorkbenchProps) {
-  const isLast = step + 1 >= totalSteps;
+export default function WorkBench({ step, totalSteps }: PrepWorkbenchProps) {
   return (
     <div
       className="relative w-full h-full min-h-[500px] bg-gradient-to-br from-gray-50 to-blue-50 rounded-lg overflow-hidden transition-all duration-300 border-2 border-dashed border-gray-300"
@@ -45,20 +44,6 @@ export default function WorkBench({ step, totalSteps, title, detail, onNext, onF
 
       <div className="absolute top-4 right-4 bg-white/90 backdrop-blur-sm rounded-lg px-3 py-2 shadow-md border border-gray-200">
         <span className="text-sm font-medium text-gray-700">Laboratory Workbench</span>
-      </div>
-
-      <div className="absolute inset-0 p-8 flex items-center justify-center">
-        <div className="bg-white/90 rounded-xl shadow-xl border border-gray-200 p-8 max-w-2xl w-full">
-          <h3 className="text-xl font-semibold text-gray-900 mb-2">{title}</h3>
-          <p className="text-gray-700 mb-6">{detail}</p>
-          <div className="flex items-center justify-end gap-3">
-            {!isLast ? (
-              <button onClick={onNext} className="px-4 py-2 rounded-md bg-blue-600 hover:bg-blue-700 text-white text-sm font-medium">Next</button>
-            ) : (
-              <button onClick={onFinish} className="px-4 py-2 rounded-md bg-emerald-600 hover:bg-emerald-700 text-white text-sm font-medium">Finish & Use Extract</button>
-            )}
-          </div>
-        </div>
       </div>
 
       <div


### PR DESCRIPTION
## Purpose

The user requested to create a workbench-style setup similar to a reference image when the "start preparation" button is pressed. They wanted to:
- Implement a workbench interface as the base of the experiment
- Show equipment sections similar to a reference design
- Display the next 5 parts/steps in the preparation process
- Remove previous components and make the interface match the desired layout until Lassaigne's extract is completed

## Code changes

- **Added new WorkBench component** (`WorkBench.tsx`) with a laboratory-style interface featuring gradient backgrounds and grid patterns
- **Enhanced VirtualLab component** with workbench preparation flow:
  - Added `showPrepWorkbench` state to control workbench display
  - Modified `startPreparation()` to show workbench instead of simple step list
  - Created 3-column layout (Equipment | Workbench | Analysis) during preparation
- **Equipment section redesign** with visual equipment cards including:
  - Ignition Tube, Sodium Piece, Organic Compound, Water Bath, Filter Paper & Funnel
  - Hover effects and proper iconography for each equipment type
- **Live analysis panel** showing current state and completed steps with safety warnings
- **Progress tracking** with step indicators and guided workflow
- **Conditional rendering** to hide preparation cards once workbench is active

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 54`

🔗 [Edit in Builder.io](https://builder.io/app/projects/068fca18ed4c4ec2a3932eb375aa30ff/echo-den)

👀 [Preview Link](https://068fca18ed4c4ec2a3932eb375aa30ff-echo-den.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>068fca18ed4c4ec2a3932eb375aa30ff</projectId>-->
<!--<branchName>echo-den</branchName>-->