### PR TITLE
Update WorkBench to hide placeholder and show sodium in tube

### DIFF
--- a/client/src/experiments/LassaigneTest/components/WorkBench.tsx
+++ b/client/src/experiments/LassaigneTest/components/WorkBench.tsx
@@ -89,54 +89,66 @@ export default function WorkBench({ step, totalSteps, equipmentItems }: PrepWork
         }}
       />
 
-      {placed.map((p, idx) => {
-        const item = findItem(p.id);
-        if (!item) return null;
-        const Icon =
-          p.id === "ignition-tube"
-            ? TestTube
-            : p.id === "sodium-piece"
-            ? Beaker
-            : p.id === "organic-compound"
-            ? FlaskConical
-            : p.id === "water-bath"
-            ? Droplets
-            : Filter;
-        const colorClass =
-          p.id === "ignition-tube"
-            ? "text-blue-600"
-            : p.id === "sodium-piece"
-            ? "text-emerald-600"
-            : p.id === "organic-compound"
-            ? "text-purple-600"
-            : p.id === "water-bath"
-            ? "text-blue-500"
-            : "text-amber-600";
-        return (
-          <div
-            key={`${p.id}-${idx}`}
-            className="absolute select-none"
-            style={{ left: p.x, top: p.y }}
-          >
-            <div className="flex flex-col items-center">
-              <div className={`${p.id === "ignition-tube" ? "w-48 h-56" : "w-16 h-16"} rounded-lg bg-white border-2 border-blue-200 shadow-sm flex items-center justify-center ${colorClass}`}>
-                {p.id === "ignition-tube" ? (
-                  <img
-                    src="https://cdn.builder.io/api/v1/image/assets%2Fc52292a04d4c4255a87bdaa80a28beb9%2F320141ac949c402cb646f053900e49f8?format=webp&width=800"
-                    alt="Fusion Tube"
-                    className="max-w-[144px] max-h-[168px] object-contain"
-                  />
-                ) : (
-                  <Icon className="w-6 h-6" />
-                )}
+      {(() => {
+        const hasIgnitionTube = placed.some(p => p.id === "ignition-tube");
+        const hasSodiumPiece = placed.some(p => p.id === "sodium-piece");
+        return placed.map((p, idx) => {
+          const item = findItem(p.id);
+          if (!item) return null;
+          if (p.id === "sodium-piece" && hasIgnitionTube) return null;
+          const Icon =
+            p.id === "ignition-tube"
+              ? TestTube
+              : p.id === "sodium-piece"
+              ? Beaker
+              : p.id === "organic-compound"
+              ? FlaskConical
+              : p.id === "water-bath"
+              ? Droplets
+              : Filter;
+          const colorClass =
+            p.id === "ignition-tube"
+              ? "text-blue-600"
+              : p.id === "sodium-piece"
+              ? "text-emerald-600"
+              : p.id === "organic-compound"
+              ? "text-purple-600"
+              : p.id === "water-bath"
+              ? "text-blue-500"
+              : "text-amber-600";
+          return (
+            <div
+              key={`${p.id}-${idx}`}
+              className="absolute select-none"
+              style={{ left: p.x, top: p.y }}
+            >
+              <div className="flex flex-col items-center">
+                <div className={`${p.id === "ignition-tube" ? "w-48 h-56" : "w-16 h-16"} relative rounded-lg bg-white border-2 border-blue-200 shadow-sm flex items-center justify-center ${colorClass}`}>
+                  {p.id === "ignition-tube" ? (
+                    <>
+                      <img
+                        src="https://cdn.builder.io/api/v1/image/assets%2Fc52292a04d4c4255a87bdaa80a28beb9%2F320141ac949c402cb646f053900e49f8?format=webp&width=800"
+                        alt="Fusion Tube"
+                        className="max-w-[144px] max-h-[168px] object-contain"
+                      />
+                      {hasSodiumPiece && (
+                        <div className="absolute bottom-6 left-1/2 -translate-x-1/2 pointer-events-none">
+                          <div className="w-10 h-6 rounded-[3px] bg-gradient-to-b from-gray-200 to-gray-500 border border-gray-400 shadow-sm" />
+                        </div>
+                      )}
+                    </>
+                  ) : (
+                    <Icon className="w-6 h-6" />
+                  )}
+                </div>
+                <span className="mt-1 text-xs font-medium text-gray-700 bg-white/80 px-2 py-0.5 rounded-md border border-gray-200">
+                  {item.label}
+                </span>
               </div>
-              <span className="mt-1 text-xs font-medium text-gray-700 bg-white/80 px-2 py-0.5 rounded-md border border-gray-200">
-                {item.label}
-              </span>
             </div>
-          </div>
-        );
-      })}
+          );
+        });
+      })()}
 
       {placed.length === 0 && (
         <div className="absolute inset-0 flex items-center justify-center pointer-events-none">

--- a/client/src/experiments/LassaigneTest/components/WorkBench.tsx
+++ b/client/src/experiments/LassaigneTest/components/WorkBench.tsx
@@ -122,7 +122,7 @@ export default function WorkBench({ step, totalSteps, equipmentItems }: PrepWork
               <div className={`${p.id === "ignition-tube" ? "w-48 h-56" : "w-16 h-16"} rounded-lg bg-white border-2 border-blue-200 shadow-sm flex items-center justify-center ${colorClass}`}>
                 {p.id === "ignition-tube" ? (
                   <img
-                    src="https://cdn.builder.io/api/v1/image/assets%2Fc52292a04d4c4255a87bdaa80a28beb9%2F4e40c21fded741afb4c81260fb6ebe5f?format=webp&width=800"
+                    src="https://cdn.builder.io/api/v1/image/assets%2Fc52292a04d4c4255a87bdaa80a28beb9%2F320141ac949c402cb646f053900e49f8?format=webp&width=800"
                     alt="Fusion Tube"
                     className="max-w-[144px] max-h-[168px] object-contain"
                   />

--- a/client/src/experiments/LassaigneTest/components/WorkBench.tsx
+++ b/client/src/experiments/LassaigneTest/components/WorkBench.tsx
@@ -132,8 +132,14 @@ export default function WorkBench({ step, totalSteps, equipmentItems }: PrepWork
                         className="max-w-[144px] max-h-[168px] object-contain"
                       />
                       {hasSodiumPiece && (
-                        <div className="absolute bottom-6 left-1/2 -translate-x-1/2 pointer-events-none">
-                          <div className="w-10 h-6 rounded-[3px] bg-gradient-to-b from-gray-200 to-gray-500 border border-gray-400 shadow-sm" />
+                        <div className="absolute bottom-8 left-1/2 -translate-x-1/2 pointer-events-none">
+                          <div
+                            className="w-6 h-6 rounded-full border border-gray-400 shadow-md"
+                            style={{
+                              background:
+                                "radial-gradient(circle at 35% 35%, rgba(255,255,255,0.9), rgba(229,231,235,0.9) 40%, #9ca3af 70%, #6b7280 100%)",
+                            }}
+                          />
                         </div>
                       )}
                     </>

--- a/client/src/experiments/LassaigneTest/components/WorkBench.tsx
+++ b/client/src/experiments/LassaigneTest/components/WorkBench.tsx
@@ -138,11 +138,13 @@ export default function WorkBench({ step, totalSteps, equipmentItems }: PrepWork
         );
       })}
 
-      <div className="absolute inset-0 flex items-center justify-center pointer-events-none">
-        <div className="text-sm text-blue-500 bg-blue-50 border border-blue-200 rounded-md px-3 py-1 shadow-sm">
-          Drag equipment here
+      {placed.length === 0 && (
+        <div className="absolute inset-0 flex items-center justify-center pointer-events-none">
+          <div className="text-sm text-blue-500 bg-blue-50 border border-blue-200 rounded-md px-3 py-1 shadow-sm">
+            Drag equipment here
+          </div>
         </div>
-      </div>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## Purpose

This PR implements several UI improvements for the WorkBench component based on user feedback:
- Remove the "drag equipment here" placeholder when any equipment is placed
- Display a fusion tube image when the ignition tube is dropped
- Show a sodium metal ball inside the fusion tube when both items are present
- Hide the standalone sodium piece when it's contained within the fusion tube

## Code changes

- **Conditional placeholder rendering**: The "drag equipment here" message now only appears when no equipment is placed (`placed.length === 0`)
- **Updated fusion tube image**: Changed the image URL for the ignition-tube to display the fusion tube visual
- **Sodium integration logic**: Added logic to hide the sodium-piece item when an ignition-tube is present, and instead render a small metallic ball inside the fusion tube
- **Visual sodium representation**: Created a styled div with radial gradient to represent the sodium metal ball, positioned at the bottom center of the fusion tube
- **Improved component structure**: Wrapped the rendering logic in an IIFE to handle the conditional display logic more cleanly

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 56`

🔗 [Edit in Builder.io](https://builder.io/app/projects/2ee0f9722977418387ca5eea543b252b/pulse-haven)

👀 [Preview Link](https://2ee0f9722977418387ca5eea543b252b-pulse-haven.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>2ee0f9722977418387ca5eea543b252b</projectId>-->
<!--<branchName>pulse-haven</branchName>-->