### PR TITLE
Display final volume used in test tube UI components

### DIFF
--- a/client/src/components/VirtualLab/Equipment.tsx
+++ b/client/src/components/VirtualLab/Equipment.tsx
@@ -78,6 +78,16 @@ export const Equipment: React.FC<EquipmentProps> = ({
 
   // Heating states for test tube
   const [showHeatingMessage, setShowHeatingMessage] = useState(false);
+  const [finalVolumeUsed, setFinalVolumeUsed] = useState<number | null>(null);
+
+  useEffect(() => {
+    const handler = (e: any) => {
+      const v = e?.detail?.volumeUsed;
+      if (typeof v === 'number' && !isNaN(v)) setFinalVolumeUsed(v);
+    };
+    window.addEventListener('finalVolumeUsedUpdated', handler as EventListener);
+    return () => window.removeEventListener('finalVolumeUsedUpdated', handler as EventListener);
+  }, []);
   const [useHeatedImage, setUseHeatedImage] = useState(false);
   const [heatingStartTime, setHeatingStartTime] = useState<number | null>(null);
   const [showEndothermicMessage, setShowEndothermicMessage] = useState(false);
@@ -646,9 +656,9 @@ export const Equipment: React.FC<EquipmentProps> = ({
             }}
           />
 
-          {/* Current volume badge */}
+          {/* Current volume badge (shows Final Volume Used if available) */}
           <div className="absolute -bottom-6 left-1/2 -translate-x-1/2 bg-white/90 backdrop-blur-sm px-2 py-0.5 rounded-full border border-gray-300 shadow-sm text-[10px] font-semibold text-gray-700">
-            {`${Math.max(0, chemicals.reduce((sum, c) => sum + (c.amount || 0), 0)).toFixed(1)} mL added`}
+            {`${(finalVolumeUsed ?? Math.max(0, chemicals.reduce((sum, c) => sum + (c.amount || 0), 0))).toFixed(1)} mL`}
           </div>
 
           {/* Pink cobalt animation effects */}

--- a/client/src/components/VirtualLab/Equipment.tsx
+++ b/client/src/components/VirtualLab/Equipment.tsx
@@ -604,7 +604,7 @@ export const Equipment: React.FC<EquipmentProps> = ({
         <div className="relative group">
           {/* Volume label above test tube */}
           <div className="absolute -top-8 left-1/2 transform -translate-x-1/2 bg-white/90 backdrop-blur-sm px-3 py-1 rounded-full border border-gray-300 shadow-sm">
-            <span className="text-xs font-semibold text-gray-700">10 mL test tube</span>
+            <span className="text-xs font-semibold text-gray-700">20 mL test tube</span>
           </div>
 
           <img
@@ -645,6 +645,11 @@ export const Equipment: React.FC<EquipmentProps> = ({
                   : 1,
             }}
           />
+
+          {/* Current volume badge */}
+          <div className="absolute -bottom-6 left-1/2 -translate-x-1/2 bg-white/90 backdrop-blur-sm px-2 py-0.5 rounded-full border border-gray-300 shadow-sm text-[10px] font-semibold text-gray-700">
+            {`${Math.max(0, chemicals.reduce((sum, c) => sum + (c.amount || 0), 0)).toFixed(1)} mL added`}
+          </div>
 
           {/* Pink cobalt animation effects */}
           {isCobaltAnimation && (

--- a/client/src/components/VirtualLab/ResultsPanel.tsx
+++ b/client/src/components/VirtualLab/ResultsPanel.tsx
@@ -68,6 +68,14 @@ export const ResultsPanel: React.FC<ResultsPanelProps> = ({ results, onClear }) 
       };
 
       setTitrationTrials(prev => [...prev, trial]);
+
+      // Broadcast latest final volume used so other UI can reflect it
+      try {
+        window.dispatchEvent(
+          new CustomEvent('finalVolumeUsedUpdated', { detail: { volumeUsed } })
+        );
+      } catch {}
+
       setNewTrial({
         initialReading: '',
         finalReading: '',

--- a/client/src/experiments/EquilibriumShift/components/Equipment.tsx
+++ b/client/src/experiments/EquilibriumShift/components/Equipment.tsx
@@ -126,6 +126,10 @@ export const Equipment: React.FC<EquipmentProps> = ({
           {id === 'test-tube' ? (
             <div className="relative">
               <div className="relative w-32 h-72">
+                {/* Current volume badge */}
+                <div className="absolute -top-6 left-1/2 -translate-x-1/2 bg-white/90 backdrop-blur-sm px-2 py-0.5 rounded-full border border-gray-300 shadow-sm text-[10px] font-semibold text-gray-700">
+                  {`${Math.max(0, volume || 0).toFixed(1)} mL`}
+                </div>
                 {/* Test tube image */}
                 <img
                   src="https://cdn.builder.io/api/v1/image/assets%2F5b489eed84cd44f89c5431dbe9fd14d3%2F3f3b9fb2343b4e74a0b66661affefadb?format=webp&width=800"
@@ -219,9 +223,9 @@ export const Equipment: React.FC<EquipmentProps> = ({
 export const LAB_EQUIPMENT = [
   {
     id: 'test-tube',
-    name: 'Test Tube',
+    name: '20 mL Test Tube',
     icon: <TestTube className="w-8 h-8" />,
-    description: 'Glass test tube for reactions'
+    description: 'Glass test tube for reactions (20 mL capacity)'
   },
   {
     id: 'cobalt-ii-solution',

--- a/client/src/experiments/EquilibriumShift/components/Equipment.tsx
+++ b/client/src/experiments/EquilibriumShift/components/Equipment.tsx
@@ -1,4 +1,5 @@
 import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { Button } from "@/components/ui/button";
 import { X, TestTube, Beaker, Droplets } from "lucide-react";

--- a/client/src/experiments/EquilibriumShift/components/Equipment.tsx
+++ b/client/src/experiments/EquilibriumShift/components/Equipment.tsx
@@ -1,4 +1,3 @@
-import React, { useState } from "react";
 import React, { useEffect, useState } from "react";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { Button } from "@/components/ui/button";

--- a/client/src/experiments/EquilibriumShift/components/Equipment.tsx
+++ b/client/src/experiments/EquilibriumShift/components/Equipment.tsx
@@ -31,6 +31,16 @@ export const Equipment: React.FC<EquipmentProps> = ({
   isActive = false,
 }) => {
   const [isDragging, setIsDragging] = useState(false);
+  const [finalVolumeUsed, setFinalVolumeUsed] = useState<number | null>(null);
+
+  useEffect(() => {
+    const handler = (e: any) => {
+      const v = e?.detail?.volumeUsed;
+      if (typeof v === 'number' && !isNaN(v)) setFinalVolumeUsed(v);
+    };
+    window.addEventListener('finalVolumeUsedUpdated', handler as EventListener);
+    return () => window.removeEventListener('finalVolumeUsedUpdated', handler as EventListener);
+  }, []);
 
   const handleDragStart = (e: React.DragEvent) => {
     if (disabled) return;
@@ -126,9 +136,9 @@ export const Equipment: React.FC<EquipmentProps> = ({
           {id === 'test-tube' ? (
             <div className="relative">
               <div className="relative w-32 h-72">
-                {/* Current volume badge */}
+                {/* Current volume badge (shows Final Volume Used if available) */}
                 <div className="absolute -top-6 left-1/2 -translate-x-1/2 bg-white/90 backdrop-blur-sm px-2 py-0.5 rounded-full border border-gray-300 shadow-sm text-[10px] font-semibold text-gray-700">
-                  {`${Math.max(0, volume || 0).toFixed(1)} mL`}
+                  {`${(finalVolumeUsed ?? volume ?? 0).toFixed(1)} mL`}
                 </div>
                 {/* Test tube image */}
                 <img

--- a/client/src/experiments/EquilibriumShift/data.ts
+++ b/client/src/experiments/EquilibriumShift/data.ts
@@ -9,9 +9,9 @@ const EquilibriumShiftData = {
   rating: 4.9,
   imageUrl: "https://images.unsplash.com/photo-1576086213369-97a306d36557?ixlib=rb-4.0.3&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=800&h=400",
   equipment: [
-    "Test Tube",
+    "20 mL Test Tube",
     "Reagent Bottles",
-    "Graduated Droppers", 
+    "Graduated Droppers",
     "Stirring Rod",
     "Thermometer",
     "Color Chart"

--- a/client/src/experiments/LassaigneTest/components/WorkBench.tsx
+++ b/client/src/experiments/LassaigneTest/components/WorkBench.tsx
@@ -132,7 +132,7 @@ export default function WorkBench({ step, totalSteps, equipmentItems }: PrepWork
                         className="max-w-[144px] max-h-[168px] object-contain"
                       />
                       {hasSodiumPiece && (
-                        <div className="absolute bottom-12 left-[53%] -translate-x-1/2 pointer-events-none">
+                        <div className="absolute bottom-10 left-[53%] -translate-x-1/2 pointer-events-none">
                           <div
                             className="w-3 h-3 rounded-full border border-gray-400 shadow-md"
                             style={{

--- a/client/src/experiments/LassaigneTest/components/WorkBench.tsx
+++ b/client/src/experiments/LassaigneTest/components/WorkBench.tsx
@@ -134,7 +134,7 @@ export default function WorkBench({ step, totalSteps, equipmentItems }: PrepWork
                       {hasSodiumPiece && (
                         <div className="absolute bottom-8 left-1/2 -translate-x-1/2 pointer-events-none">
                           <div
-                            className="w-6 h-6 rounded-full border border-gray-400 shadow-md"
+                            className="w-3 h-3 rounded-full border border-gray-400 shadow-md"
                             style={{
                               background:
                                 "radial-gradient(circle at 35% 35%, rgba(255,255,255,0.9), rgba(229,231,235,0.9) 40%, #9ca3af 70%, #6b7280 100%)",

--- a/client/src/experiments/LassaigneTest/components/WorkBench.tsx
+++ b/client/src/experiments/LassaigneTest/components/WorkBench.tsx
@@ -132,7 +132,7 @@ export default function WorkBench({ step, totalSteps, equipmentItems }: PrepWork
                         className="max-w-[144px] max-h-[168px] object-contain"
                       />
                       {hasSodiumPiece && (
-                        <div className="absolute bottom-12 left-1/2 -translate-x-1/2 pointer-events-none">
+                        <div className="absolute bottom-12 left-[53%] -translate-x-1/2 pointer-events-none">
                           <div
                             className="w-3 h-3 rounded-full border border-gray-400 shadow-md"
                             style={{

--- a/client/src/experiments/LassaigneTest/components/WorkBench.tsx
+++ b/client/src/experiments/LassaigneTest/components/WorkBench.tsx
@@ -132,7 +132,7 @@ export default function WorkBench({ step, totalSteps, equipmentItems }: PrepWork
                         className="max-w-[144px] max-h-[168px] object-contain"
                       />
                       {hasSodiumPiece && (
-                        <div className="absolute bottom-8 left-1/2 -translate-x-1/2 pointer-events-none">
+                        <div className="absolute bottom-12 left-1/2 -translate-x-1/2 pointer-events-none">
                           <div
                             className="w-3 h-3 rounded-full border border-gray-400 shadow-md"
                             style={{


### PR DESCRIPTION
## Purpose
The user requested to display the same "final volume used" data from the results and analysis section in the main equipment UI. This change addresses a runtime error and ensures consistent volume information is shown across different components of the virtual lab interface.

## Code changes
- **Added volume tracking**: Implemented `finalVolumeUsed` state and event listener in Equipment components to track volume updates from titration results
- **Enhanced UI display**: Added volume badges below test tubes showing current volume (prioritizing final volume used when available)
- **Event broadcasting**: Added custom event dispatch in ResultsPanel to communicate volume changes to other components
- **Updated capacity labels**: Changed test tube labels from "10 mL" to "20 mL" to reflect correct capacity
- **Improved positioning**: Adjusted sodium piece positioning in Lassaigne test for better visual accuracy

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 57`

🔗 [Edit in Builder.io](https://builder.io/app/projects/2ee0f9722977418387ca5eea543b252b/pixel-verse)

👀 [Preview Link](https://2ee0f9722977418387ca5eea543b252b-pixel-verse.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>2ee0f9722977418387ca5eea543b252b</projectId>-->
<!--<branchName>pixel-verse</branchName>-->