### PR TITLE
Add fusion tube visual effects and experiment controls

### DIFF
--- a/client/src/experiments/LassaigneTest/components/VirtualLab.tsx
+++ b/client/src/experiments/LassaigneTest/components/VirtualLab.tsx
@@ -1,7 +1,7 @@
 import React, { useMemo, useState } from "react";
 import { Card, CardContent } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
-import { CheckCircle, Beaker, FlaskConical, Droplets, Sparkles, Eraser, Play, Wrench, Info, TestTube, Filter } from "lucide-react";
+import { CheckCircle, Beaker, FlaskConical, Droplets, Sparkles, Eraser, Play, Wrench, Info, TestTube, Filter, Flame } from "lucide-react";
 import type { ExperimentMode } from "../types";
 import WorkBench from "./WorkBench";
 
@@ -66,6 +66,7 @@ export default function VirtualLab({
   const equipmentItems = [
     { id: "ignition-tube", label: "Fusion Tube", icon: <TestTube className="w-8 h-8 text-blue-600 mb-2" /> },
     { id: "sodium-piece", label: "Sodium Piece (under kerosene)", icon: <Beaker className="w-8 h-8 text-emerald-600 mb-2" /> },
+    { id: "bunsen-burner", label: "Bunsen Burner", icon: <Flame className="w-8 h-8 text-orange-500 mb-2" /> },
     { id: "organic-compound", label: "Organic Compound", icon: <FlaskConical className="w-8 h-8 text-purple-600 mb-2" /> },
     { id: "water-bath", label: "Water Bath", icon: <Droplets className="w-8 h-8 text-blue-500 mb-2" /> },
     { id: "filter-funnel", label: "Filter Paper & Funnel", icon: <Filter className="w-8 h-8 text-amber-600 mb-2" /> },

--- a/client/src/experiments/LassaigneTest/components/VirtualLab.tsx
+++ b/client/src/experiments/LassaigneTest/components/VirtualLab.tsx
@@ -316,6 +316,34 @@ export default function VirtualLab({
                   Drag equipment into the workbench center area.
                 </div>
               </div>
+
+              <div className="bg-white/90 backdrop-blur-sm rounded-xl p-4 border border-gray-200 shadow-sm">
+                <h4 className="text-sm font-semibold text-gray-700 mb-3">Chemical Equations</h4>
+                <div className="text-center text-xs font-mono leading-relaxed bg-gray-50 rounded-lg p-3 border">
+                  <div>Na + C + N → NaCN</div>
+                  <div>2Na + S → Na₂S</div>
+                  <div>Na + X → NaX (X = Cl, Br, I)</div>
+                </div>
+                <div className="text-center text-xs text-gray-500 mt-2">Sodium fusion converts elements to ionic salts</div>
+              </div>
+
+              <div className="space-y-2">
+                <Button
+                  onClick={() => onStepUndo()}
+                  variant="outline"
+                  className="w-full bg-red-50 border-red-200 text-red-700 hover:bg-red-100"
+                  disabled={mode.currentGuidedStep <= 0}
+                >
+                  <ArrowLeft className="w-4 h-4 mr-2" /> Undo Step {mode.currentGuidedStep + 1}
+                </Button>
+                <Button
+                  onClick={onReset}
+                  variant="outline"
+                  className="w-full bg-red-50 border-red-200 text-red-700 hover:bg-red-100"
+                >
+                  <RotateCcw className="w-4 h-4 mr-2" /> Reset Experiment
+                </Button>
+              </div>
             </div>
 
             {/* Workbench - Center */}

--- a/client/src/experiments/LassaigneTest/components/VirtualLab.tsx
+++ b/client/src/experiments/LassaigneTest/components/VirtualLab.tsx
@@ -1,7 +1,7 @@
 import React, { useMemo, useState } from "react";
 import { Card, CardContent } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
-import { CheckCircle, Beaker, FlaskConical, Droplets, Sparkles, Eraser, Play, Wrench, Info, TestTube, Filter, Flame } from "lucide-react";
+import { CheckCircle, Beaker, FlaskConical, Droplets, Sparkles, Eraser, Play, Wrench, Info, TestTube, Filter, Flame, ArrowLeft, RotateCcw } from "lucide-react";
 import type { ExperimentMode } from "../types";
 import WorkBench from "./WorkBench";
 

--- a/client/src/experiments/LassaigneTest/components/VirtualLab.tsx
+++ b/client/src/experiments/LassaigneTest/components/VirtualLab.tsx
@@ -417,6 +417,24 @@ export default function VirtualLab({
               </CardContent>
             </Card>
           ))}
+
+          <div className="lg:col-span-2 space-y-2">
+            <Button
+              onClick={() => onStepUndo()}
+              variant="outline"
+              className="w-full bg-red-50 border-red-200 text-red-700 hover:bg-red-100"
+              disabled={mode.currentGuidedStep <= 0}
+            >
+              <ArrowLeft className="w-4 h-4 mr-2" /> Undo Step {mode.currentGuidedStep + 1}
+            </Button>
+            <Button
+              onClick={onReset}
+              variant="outline"
+              className="w-full bg-red-50 border-red-200 text-red-700 hover:bg-red-100"
+            >
+              <RotateCcw className="w-4 h-4 mr-2" /> Reset Experiment
+            </Button>
+          </div>
         </div>
       )}
     </div>

--- a/client/src/experiments/LassaigneTest/components/WorkBench.tsx
+++ b/client/src/experiments/LassaigneTest/components/WorkBench.tsx
@@ -149,18 +149,17 @@ export default function WorkBench({ step, totalSteps, equipmentItems }: PrepWork
                         </div>
                       )}
                       {hasOrganicCompound && (
-                        <div className="absolute bottom-10 left-[53%] -translate-x-1/2 pointer-events-none">
-                          <div className="relative w-6 h-16 rounded-full overflow-hidden">
-                            <div
-                              className="absolute bottom-0 left-0 right-0"
-                              style={{
-                                height: "24px",
-                                background: "linear-gradient(to top, #f59e0b, #fde68a)",
-                                borderTopLeftRadius: "9999px",
-                                borderTopRightRadius: "9999px",
-                              }}
-                            />
-                          </div>
+                        <div className="absolute inset-0 pointer-events-none flex items-end justify-center">
+                          <div
+                            style={{
+                              width: 24,
+                              height: "20%",
+                              background: "linear-gradient(to top, #f59e0b, #fde68a)",
+                              borderTopLeftRadius: 10,
+                              borderTopRightRadius: 10,
+                              opacity: 0.95,
+                            }}
+                          />
                         </div>
                       )}
                     </>

--- a/client/src/experiments/LassaigneTest/components/WorkBench.tsx
+++ b/client/src/experiments/LassaigneTest/components/WorkBench.tsx
@@ -113,6 +113,8 @@ export default function WorkBench({ step, totalSteps, equipmentItems }: PrepWork
               ? "text-blue-600"
               : p.id === "sodium-piece"
               ? "text-emerald-600"
+              : p.id === "bunsen-burner"
+              ? "text-orange-500"
               : p.id === "organic-compound"
               ? "text-purple-600"
               : p.id === "water-bath"

--- a/client/src/experiments/LassaigneTest/components/WorkBench.tsx
+++ b/client/src/experiments/LassaigneTest/components/WorkBench.tsx
@@ -149,17 +149,19 @@ export default function WorkBench({ step, totalSteps, equipmentItems }: PrepWork
                         </div>
                       )}
                       {hasOrganicCompound && (
-                        <div className="absolute inset-0 pointer-events-none flex items-end justify-center">
-                          <div
-                            style={{
-                              width: 24,
-                              height: "20%",
-                              background: "linear-gradient(to top, #f59e0b, #fde68a)",
-                              borderTopLeftRadius: 10,
-                              borderTopRightRadius: 10,
-                              opacity: 0.95,
-                            }}
-                          />
+                        <div className="absolute bottom-12 left-[53%] -translate-x-1/2 pointer-events-none">
+                          <div className="relative w-[22px] h-[110px] overflow-hidden">
+                            <div
+                              className="absolute bottom-0 left-0 right-0"
+                              style={{
+                                height: "22%",
+                                background: "linear-gradient(to top, #f59e0b, #fde68a)",
+                                borderTopLeftRadius: 8,
+                                borderTopRightRadius: 8,
+                                opacity: 0.95,
+                              }}
+                            />
+                          </div>
                         </div>
                       )}
                     </>

--- a/client/src/experiments/LassaigneTest/components/WorkBench.tsx
+++ b/client/src/experiments/LassaigneTest/components/WorkBench.tsx
@@ -92,10 +92,12 @@ export default function WorkBench({ step, totalSteps, equipmentItems }: PrepWork
       {(() => {
         const hasIgnitionTube = placed.some(p => p.id === "ignition-tube");
         const hasSodiumPiece = placed.some(p => p.id === "sodium-piece");
+        const hasOrganicCompound = placed.some(p => p.id === "organic-compound");
         return placed.map((p, idx) => {
           const item = findItem(p.id);
           if (!item) return null;
           if (p.id === "sodium-piece" && hasIgnitionTube) return null;
+          if (p.id === "organic-compound" && hasIgnitionTube) return null;
           const Icon =
             p.id === "ignition-tube"
               ? TestTube
@@ -142,6 +144,22 @@ export default function WorkBench({ step, totalSteps, equipmentItems }: PrepWork
                             style={{
                               background:
                                 "radial-gradient(circle at 35% 35%, rgba(255,255,255,0.9), rgba(229,231,235,0.9) 40%, #9ca3af 70%, #6b7280 100%)",
+                            }}
+                          />
+                        </div>
+                      )}
+                      {hasOrganicCompound && (
+                        <div className="absolute bottom-8 left-1/2 -translate-x-1/2 pointer-events-none">
+                          <div
+                            className="w-16 h-6 shadow-sm"
+                            style={{
+                              background:
+                                "linear-gradient(to top, #f59e0b 10%, #fde68a 90%)",
+                              clipPath:
+                                "polygon(0% 100%, 8% 70%, 20% 55%, 35% 45%, 50% 40%, 65% 45%, 80% 55%, 92% 70%, 100% 100%)",
+                              border: "1px solid rgba(0,0,0,0.08)",
+                              borderRadius: "2px",
+                              opacity: 0.95,
                             }}
                           />
                         </div>

--- a/client/src/experiments/LassaigneTest/components/WorkBench.tsx
+++ b/client/src/experiments/LassaigneTest/components/WorkBench.tsx
@@ -101,6 +101,8 @@ export default function WorkBench({ step, totalSteps, equipmentItems }: PrepWork
               ? TestTube
               : p.id === "sodium-piece"
               ? Beaker
+              : p.id === "bunsen-burner"
+              ? Flame
               : p.id === "organic-compound"
               ? FlaskConical
               : p.id === "water-bath"

--- a/client/src/experiments/LassaigneTest/components/WorkBench.tsx
+++ b/client/src/experiments/LassaigneTest/components/WorkBench.tsx
@@ -16,7 +16,7 @@ interface PrepWorkbenchProps {
 }
 
 import { useRef, useState } from "react";
-import { TestTube, Beaker, FlaskConical, Droplets, Filter } from "lucide-react";
+import { TestTube, Beaker, FlaskConical, Droplets, Filter, Flame } from "lucide-react";
 
 export default function WorkBench({ step, totalSteps, equipmentItems }: PrepWorkbenchProps) {
   const containerRef = useRef<HTMLDivElement | null>(null);

--- a/client/src/experiments/LassaigneTest/components/WorkBench.tsx
+++ b/client/src/experiments/LassaigneTest/components/WorkBench.tsx
@@ -149,19 +149,18 @@ export default function WorkBench({ step, totalSteps, equipmentItems }: PrepWork
                         </div>
                       )}
                       {hasOrganicCompound && (
-                        <div className="absolute bottom-8 left-1/2 -translate-x-1/2 pointer-events-none">
-                          <div
-                            className="w-16 h-6 shadow-sm"
-                            style={{
-                              background:
-                                "linear-gradient(to top, #f59e0b 10%, #fde68a 90%)",
-                              clipPath:
-                                "polygon(0% 100%, 8% 70%, 20% 55%, 35% 45%, 50% 40%, 65% 45%, 80% 55%, 92% 70%, 100% 100%)",
-                              border: "1px solid rgba(0,0,0,0.08)",
-                              borderRadius: "2px",
-                              opacity: 0.95,
-                            }}
-                          />
+                        <div className="absolute bottom-10 left-[53%] -translate-x-1/2 pointer-events-none">
+                          <div className="relative w-6 h-16 rounded-full overflow-hidden">
+                            <div
+                              className="absolute bottom-0 left-0 right-0"
+                              style={{
+                                height: "24px",
+                                background: "linear-gradient(to top, #f59e0b, #fde68a)",
+                                borderTopLeftRadius: "9999px",
+                                borderTopRightRadius: "9999px",
+                              }}
+                            />
+                          </div>
                         </div>
                       )}
                     </>

--- a/client/src/experiments/OxalicAcidStandardization/components/OxalicAcidApp.tsx
+++ b/client/src/experiments/OxalicAcidStandardization/components/OxalicAcidApp.tsx
@@ -18,6 +18,7 @@ export default function OxalicAcidApp({ onBack }: OxalicAcidAppProps) {
   const [isRunning, setIsRunning] = useState(false);
   const [timer, setTimer] = useState(0);
   const [experimentStarted, setExperimentStarted] = useState(false);
+  const [resetKey, setResetKey] = useState(0);
 
   const experiment = OxalicAcidData;
   const [match, params] = useRoute("/experiment/:id");

--- a/client/src/experiments/OxalicAcidStandardization/components/OxalicAcidApp.tsx
+++ b/client/src/experiments/OxalicAcidStandardization/components/OxalicAcidApp.tsx
@@ -201,6 +201,7 @@ export default function OxalicAcidApp({ onBack }: OxalicAcidAppProps) {
           {/* Virtual Lab */}
           <div className="lg:col-span-3">
             <OxalicAcidVirtualLab
+              key={resetKey}
               step={experiment.stepDetails[currentStep]}
               onStepComplete={handleStepComplete}
               isActive={true}
@@ -213,6 +214,9 @@ export default function OxalicAcidApp({ onBack }: OxalicAcidAppProps) {
               isRunning={isRunning}
               setIsRunning={setIsRunning}
               onResetTimer={handleResetTimer}
+              onUndoStep={handleUndoStep}
+              onResetExperiment={handleResetExperiment}
+              currentStepIndex={currentStep + 1}
             />
           </div>
         </div>

--- a/client/src/experiments/OxalicAcidStandardization/components/OxalicAcidApp.tsx
+++ b/client/src/experiments/OxalicAcidStandardization/components/OxalicAcidApp.tsx
@@ -74,6 +74,18 @@ export default function OxalicAcidApp({ onBack }: OxalicAcidAppProps) {
     setIsRunning(false);
   };
 
+  const handleUndoStep = () => {
+    if (currentStep > 0) setCurrentStep((s) => s - 1);
+  };
+
+  const handleResetExperiment = () => {
+    setCurrentStep(0);
+    setIsRunning(false);
+    setTimer(0);
+    setExperimentStarted(false);
+    setResetKey((k) => k + 1);
+  };
+
   useEffect(() => {
     const total = experiment.stepDetails.length;
     const done = experimentStarted ? Math.min(currentStep + 1, total) : 0;

--- a/client/src/experiments/OxalicAcidStandardization/components/VirtualLab.tsx
+++ b/client/src/experiments/OxalicAcidStandardization/components/VirtualLab.tsx
@@ -38,6 +38,9 @@ interface OxalicAcidVirtualLabProps {
   isRunning: boolean;
   setIsRunning: (running: boolean) => void;
   onResetTimer: () => void;
+  onUndoStep: () => void;
+  onResetExperiment: () => void;
+  currentStepIndex: number;
 }
 
 function OxalicAcidVirtualLab({
@@ -53,6 +56,9 @@ function OxalicAcidVirtualLab({
   isRunning,
   setIsRunning,
   onResetTimer,
+  onUndoStep,
+  onResetExperiment,
+  currentStepIndex,
 }: OxalicAcidVirtualLabProps) {
   const [equipmentPositions, setEquipmentPositions] = useState<
     EquipmentPosition[]
@@ -371,6 +377,9 @@ function OxalicAcidVirtualLab({
           results={results}
           chemicals={OXALIC_ACID_CHEMICALS}
           equipment={OXALIC_ACID_EQUIPMENT}
+          onUndoStep={onUndoStep}
+          onResetExperiment={onResetExperiment}
+          currentStepIndex={currentStepIndex}
         />
       </div>
     </TooltipProvider>

--- a/client/src/experiments/OxalicAcidStandardization/components/WorkBench.tsx
+++ b/client/src/experiments/OxalicAcidStandardization/components/WorkBench.tsx
@@ -34,6 +34,9 @@ interface WorkBenchProps {
   results: Result[];
   chemicals: ChemicalType[];
   equipment: EquipmentType[];
+  onUndoStep: () => void;
+  onResetExperiment: () => void;
+  currentStepIndex: number;
 }
 
 export const WorkBench: React.FC<WorkBenchProps> = ({
@@ -55,6 +58,9 @@ export const WorkBench: React.FC<WorkBenchProps> = ({
   results,
   chemicals,
   equipment,
+  onUndoStep,
+  onResetExperiment,
+  currentStepIndex,
 }) => {
   const [selectedChemical, setSelectedChemical] = useState<string | null>(null);
   const [isDragOver, setIsDragOver] = useState(false);
@@ -322,6 +328,16 @@ export const WorkBench: React.FC<WorkBenchProps> = ({
             </div>
           </div>
 
+          {/* Chemical Equation */}
+          <div className="mb-6">
+            <h3 className="text-sm font-semibold text-gray-900 mb-2">Chemical Equation</h3>
+            <div className="text-xs font-mono bg-gray-50 rounded-lg p-3 border text-center leading-relaxed">
+              <div>H₂C₂O₄·2H₂O (s) → H₂C₂O₄ (aq) + 2H₂O</div>
+              <div className="mt-1">H₂C₂O₄ (aq) ⇌ 2H⁺ + C₂O₄²⁻</div>
+            </div>
+            <div className="text-center text-xs text-gray-500 mt-2">Dissolution and acid dissociation</div>
+          </div>
+
           {/* Current Step Action */}
           {canProceed && (
             <div className="mb-4">
@@ -335,6 +351,25 @@ export const WorkBench: React.FC<WorkBenchProps> = ({
               </Button>
             </div>
           )}
+
+          {/* Undo and Reset Controls */}
+          <div className="space-y-2">
+            <Button
+              onClick={onUndoStep}
+              variant="outline"
+              className="w-full bg-red-50 border-red-200 text-red-700 hover:bg-red-100"
+              disabled={stepNumber <= 1}
+            >
+              Undo Step {currentStepIndex}
+            </Button>
+            <Button
+              onClick={onResetExperiment}
+              variant="outline"
+              className="w-full bg-red-50 border-red-200 text-red-700 hover:bg-red-100"
+            >
+              Reset Experiment
+            </Button>
+          </div>
         </div>
 
         {/* Workbench Area */}


### PR DESCRIPTION
## Purpose

The user requested visual improvements for the Lassaigne's Test experiment, specifically:
- Adding yellow color powder inside the fusion tube when organic compound is added
- Ensuring the color stays contained within the tube shape (not circular)
- Filling approximately 20% of the tube with yellow color
- Adding proper experiment controls for better user experience

## Code changes

**Visual Effects:**
- Added yellow gradient color effect inside fusion tube when organic compound is present
- Implemented proper containment within tube boundaries (22% height fill)
- Used linear gradient from amber to light amber for realistic appearance

**UI Enhancements:**
- Added Bunsen Burner equipment with flame icon
- Added chemical equations display for both experiments
- Implemented undo step and reset experiment functionality
- Added proper button controls with red styling for destructive actions

**Component Updates:**
- Enhanced WorkBench component with conditional color rendering
- Updated VirtualLab with new equipment and control buttons
- Added proper state management for experiment reset functionality

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 58`

🔗 [Edit in Builder.io](https://builder.io/app/projects/a0aa7cfb35944fc1b79ef22c63b77aa9/vibe-world)

👀 [Preview Link](https://a0aa7cfb35944fc1b79ef22c63b77aa9-vibe-world.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>a0aa7cfb35944fc1b79ef22c63b77aa9</projectId>-->
<!--<branchName>vibe-world</branchName>-->