### PR TITLE
Fix guided mode equipment placement logic and step completion

### DIFF
--- a/client/src/experiments/Titration1/components/VirtualLab.tsx
+++ b/client/src/experiments/Titration1/components/VirtualLab.tsx
@@ -247,27 +247,31 @@ export default function VirtualLab({
     // Get predefined position for this equipment
     const predefinedPosition = getEquipmentPosition(equipmentId);
 
-    // Add equipment to workbench
+    // Add equipment to workbench and compute resulting set
+    let afterIds: string[] = [];
     setEquipmentOnBench(prev => {
       const filtered = prev.filter(eq => eq.id !== equipmentId);
-      return [...filtered, {
+      const next = [...filtered, {
         id: equipmentId,
         position: predefinedPosition,
         isActive: false
       }];
+      afterIds = next.map(eq => eq.id);
+      return next;
     });
 
     setShowToast(`${equipmentId.replace('-', ' ')} placed on workbench`);
     setTimeout(() => setShowToast(""), 2000);
 
-    // Auto-complete step if it's just placing equipment (guided mode only)
+    // Auto-complete step only when all required items for this placement step are present
     if (mode.current === 'guided') {
       const currentStepData = GUIDED_STEPS[currentStep - 1];
-      const isCurrentStepPlacement = currentStepData.action.includes("Drag") && currentStepData.equipment.includes(equipmentId);
-      if (isCurrentStepPlacement && !completedSteps.includes(currentStep)) {
+      const isPlacementStep = currentStepData.action.includes("Drag");
+      const allPresent = currentStepData.equipment.every(id => afterIds.includes(id));
+      if (isPlacementStep && allPresent && !completedSteps.includes(currentStep)) {
         setTimeout(() => {
           handleStepComplete();
-        }, 1000);
+        }, 600);
       }
     }
   }, [currentStep, completedSteps, mode.current]);

--- a/client/src/experiments/Titration1/components/VirtualLab.tsx
+++ b/client/src/experiments/Titration1/components/VirtualLab.tsx
@@ -233,7 +233,11 @@ export default function VirtualLab({
     // In guided mode, enforce step equipment requirements
     if (mode.current === 'guided') {
       const currentStepData = GUIDED_STEPS[currentStep - 1];
-      if (!currentStepData.equipment.includes(equipmentId)) {
+      const allowedSoFar = new Set(
+        GUIDED_STEPS.slice(0, currentStep).flatMap((s) => s.equipment)
+      );
+      // Allow placing any equipment required up to the current step
+      if (!allowedSoFar.has(equipmentId)) {
         setShowToast(`${equipmentId.replace('-', ' ')} is not needed for step ${currentStep}. Follow the current step instructions.`);
         setTimeout(() => setShowToast(""), 3000);
         return;
@@ -259,7 +263,8 @@ export default function VirtualLab({
     // Auto-complete step if it's just placing equipment (guided mode only)
     if (mode.current === 'guided') {
       const currentStepData = GUIDED_STEPS[currentStep - 1];
-      if (currentStepData.action.includes("Drag") && !completedSteps.includes(currentStep)) {
+      const isCurrentStepPlacement = currentStepData.action.includes("Drag") && currentStepData.equipment.includes(equipmentId);
+      if (isCurrentStepPlacement && !completedSteps.includes(currentStep)) {
         setTimeout(() => {
           handleStepComplete();
         }, 1000);

--- a/client/src/experiments/Titration1/constants.ts
+++ b/client/src/experiments/Titration1/constants.ts
@@ -214,9 +214,9 @@ export const GUIDED_STEPS: GuidedStep[] = [
   {
     id: 1,
     title: "Setup Workspace",
-    description: "Drag the burette, conical flask, and pipette onto the workbench to begin the experiment.",
-    action: "Drag equipment to workbench",
-    equipment: ["burette", "conical-flask", "pipette"],
+    description: "drag the burette, pipette and the conical flask to the workbench",
+    action: "Drag the burette, pipette and the conical flask to the workbench",
+    equipment: ["burette", "pipette", "conical-flask"],
     completed: false
   },
   {


### PR DESCRIPTION
## Changes Made

### Equipment Placement Logic
- Modified equipment validation in guided mode to allow placing any equipment required up to the current step
- Changed from checking only current step equipment to checking all equipment from steps 1 through current step
- Added `allowedSoFar` set that accumulates equipment from all previous steps

### Step Auto-completion
- Updated auto-completion logic to require all equipment for the current step to be present
- Added `afterIds` array to track equipment IDs after placement
- Changed completion check from simple drag action to verifying all required equipment is present
- Reduced auto-completion delay from 1000ms to 600ms

### Step Configuration Updates
- Updated step 1 description and action text for consistency
- Reordered equipment array from `["burette", "conical-flask", "pipette"]` to `["burette", "pipette", "conical-flask"]`
- Simplified description text formatting

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 59`

🔗 [Edit in Builder.io](https://builder.io/app/projects/a0aa7cfb35944fc1b79ef22c63b77aa9/vibe-world)

👀 [Preview Link](https://a0aa7cfb35944fc1b79ef22c63b77aa9-vibe-world.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>a0aa7cfb35944fc1b79ef22c63b77aa9</projectId>-->
<!--<branchName>vibe-world</branchName>-->