### PR TITLE
Reorder bunsen burner in equipment and remove from workbench

### DIFF
--- a/client/src/experiments/LassaigneTest/components/VirtualLab.tsx
+++ b/client/src/experiments/LassaigneTest/components/VirtualLab.tsx
@@ -67,6 +67,7 @@ export default function VirtualLab({
     { id: "ignition-tube", label: "Fusion Tube", icon: <TestTube className="w-8 h-8 text-blue-600 mb-2" /> },
     { id: "sodium-piece", label: "Sodium Piece (under kerosene)", icon: <Beaker className="w-8 h-8 text-emerald-600 mb-2" /> },
     { id: "organic-compound", label: "Organic Compound", icon: <FlaskConical className="w-8 h-8 text-purple-600 mb-2" /> },
+    { id: "bunsen-burner", label: "Bunsen Burner", icon: <Flame className="w-8 h-8 text-orange-500 mb-2" /> },
     { id: "water-bath", label: "Water Bath", icon: <Droplets className="w-8 h-8 text-blue-500 mb-2" /> },
     { id: "filter-funnel", label: "Filter Paper & Funnel", icon: <Filter className="w-8 h-8 text-amber-600 mb-2" /> },
   ];

--- a/client/src/experiments/LassaigneTest/components/VirtualLab.tsx
+++ b/client/src/experiments/LassaigneTest/components/VirtualLab.tsx
@@ -66,7 +66,6 @@ export default function VirtualLab({
   const equipmentItems = [
     { id: "ignition-tube", label: "Fusion Tube", icon: <TestTube className="w-8 h-8 text-blue-600 mb-2" /> },
     { id: "sodium-piece", label: "Sodium Piece (under kerosene)", icon: <Beaker className="w-8 h-8 text-emerald-600 mb-2" /> },
-    { id: "bunsen-burner", label: "Bunsen Burner", icon: <Flame className="w-8 h-8 text-orange-500 mb-2" /> },
     { id: "organic-compound", label: "Organic Compound", icon: <FlaskConical className="w-8 h-8 text-purple-600 mb-2" /> },
     { id: "water-bath", label: "Water Bath", icon: <Droplets className="w-8 h-8 text-blue-500 mb-2" /> },
     { id: "filter-funnel", label: "Filter Paper & Funnel", icon: <Filter className="w-8 h-8 text-amber-600 mb-2" /> },

--- a/client/src/experiments/LassaigneTest/components/WorkBench.tsx
+++ b/client/src/experiments/LassaigneTest/components/WorkBench.tsx
@@ -185,10 +185,6 @@ export default function WorkBench({ step, totalSteps, equipmentItems }: PrepWork
                               className="absolute bottom-1 left-1/2 -translate-x-1/2 w-[36px] h-[72px] rounded-full"
                               style={{ background: "radial-gradient(ellipse at bottom, rgba(191,219,254,0.95) 0%, rgba(147,197,253,0.6) 60%, rgba(147,197,253,0) 80%)", animation: "flameFlicker 0.3s infinite ease-in-out reverse" }}
                             />
-                            <div
-                              className="absolute -bottom-1 left-1/2 -translate-x-1/2 w-[192px] h-[96px] rounded-full blur-md opacity-80"
-                              style={{ background: "radial-gradient(circle, rgba(59,130,246,0.6), rgba(59,130,246,0))" }}
-                            />
                           </div>
                         </div>
                       )}

--- a/client/src/experiments/LassaigneTest/components/WorkBench.tsx
+++ b/client/src/experiments/LassaigneTest/components/WorkBench.tsx
@@ -166,28 +166,6 @@ export default function WorkBench({ step, totalSteps, equipmentItems }: PrepWork
                           </div>
                         </div>
                       )}
-                      {hasBunsenBurner && (
-                        <div
-                          className="absolute -bottom-48 left-1/2 -translate-x-1/2 pointer-events-none"
-                          style={{ filter: 'drop-shadow(2px 2px 4px rgba(0,0,0,0.15))' }}
-                        >
-                          <img
-                            src="https://cdn.builder.io/api/v1/image/assets%2Fc52292a04d4c4255a87bdaa80a28beb9%2Fb8d67a4a48d04f2c845aaddc4b071ade?format=webp&width=800"
-                            alt="Bunsen Burner"
-                            className="w-[768px] h-auto"
-                          />
-                          <div className="absolute -top-4 left-1/2 -translate-x-1/2 w-36 h-48 z-30">
-                            <div
-                              className="absolute bottom-0 left-1/2 -translate-x-1/2 w-[72px] h-[120px] rounded-full blur-[1px]"
-                              style={{ background: "radial-gradient(ellipse at bottom, rgba(59,130,246,0.9) 0%, rgba(37,99,235,0.7) 55%, rgba(37,99,235,0) 70%)", animation: "flameFlicker 0.35s infinite ease-in-out" }}
-                            />
-                            <div
-                              className="absolute bottom-1 left-1/2 -translate-x-1/2 w-[36px] h-[72px] rounded-full"
-                              style={{ background: "radial-gradient(ellipse at bottom, rgba(191,219,254,0.95) 0%, rgba(147,197,253,0.6) 60%, rgba(147,197,253,0) 80%)", animation: "flameFlicker 0.3s infinite ease-in-out reverse" }}
-                            />
-                          </div>
-                        </div>
-                      )}
                     </>
                   ) : (
                     <Icon className="w-6 h-6" />

--- a/client/src/experiments/LassaigneTest/components/WorkBench.tsx
+++ b/client/src/experiments/LassaigneTest/components/WorkBench.tsx
@@ -174,19 +174,19 @@ export default function WorkBench({ step, totalSteps, equipmentItems }: PrepWork
                           <img
                             src="https://cdn.builder.io/api/v1/image/assets%2Fc52292a04d4c4255a87bdaa80a28beb9%2Fb8d67a4a48d04f2c845aaddc4b071ade?format=webp&width=800"
                             alt="Bunsen Burner"
-                            className="w-64 h-auto"
+                            className="w-80 h-auto"
                           />
-                          <div className="absolute -top-4 left-1/2 -translate-x-1/2 w-12 h-16 z-30">
+                          <div className="absolute -top-4 left-1/2 -translate-x-1/2 w-14 h-20 z-30">
                             <div
-                              className="absolute bottom-0 left-1/2 -translate-x-1/2 w-6 h-10 rounded-full blur-[1px]"
+                              className="absolute bottom-0 left-1/2 -translate-x-1/2 w-8 h-14 rounded-full blur-[1px]"
                               style={{ background: "radial-gradient(ellipse at bottom, rgba(59,130,246,0.9) 0%, rgba(37,99,235,0.7) 55%, rgba(37,99,235,0) 70%)", animation: "flameFlicker 0.35s infinite ease-in-out" }}
                             />
                             <div
-                              className="absolute bottom-1 left-1/2 -translate-x-1/2 w-3 h-6 rounded-full"
+                              className="absolute bottom-1 left-1/2 -translate-x-1/2 w-4 h-8 rounded-full"
                               style={{ background: "radial-gradient(ellipse at bottom, rgba(191,219,254,0.95) 0%, rgba(147,197,253,0.6) 60%, rgba(147,197,253,0) 80%)", animation: "flameFlicker 0.3s infinite ease-in-out reverse" }}
                             />
                             <div
-                              className="absolute -bottom-1 left-1/2 -translate-x-1/2 w-16 h-8 rounded-full blur-md opacity-80"
+                              className="absolute -bottom-1 left-1/2 -translate-x-1/2 w-20 h-10 rounded-full blur-md opacity-80"
                               style={{ background: "radial-gradient(circle, rgba(59,130,246,0.6), rgba(59,130,246,0))" }}
                             />
                           </div>

--- a/client/src/experiments/LassaigneTest/components/WorkBench.tsx
+++ b/client/src/experiments/LassaigneTest/components/WorkBench.tsx
@@ -174,19 +174,19 @@ export default function WorkBench({ step, totalSteps, equipmentItems }: PrepWork
                           <img
                             src="https://cdn.builder.io/api/v1/image/assets%2Fc52292a04d4c4255a87bdaa80a28beb9%2Fb8d67a4a48d04f2c845aaddc4b071ade?format=webp&width=800"
                             alt="Bunsen Burner"
-                            className="w-80 h-auto"
+                            className="w-[768px] h-auto"
                           />
-                          <div className="absolute -top-4 left-1/2 -translate-x-1/2 w-14 h-20 z-30">
+                          <div className="absolute -top-4 left-1/2 -translate-x-1/2 w-36 h-48 z-30">
                             <div
-                              className="absolute bottom-0 left-1/2 -translate-x-1/2 w-8 h-14 rounded-full blur-[1px]"
+                              className="absolute bottom-0 left-1/2 -translate-x-1/2 w-[72px] h-[120px] rounded-full blur-[1px]"
                               style={{ background: "radial-gradient(ellipse at bottom, rgba(59,130,246,0.9) 0%, rgba(37,99,235,0.7) 55%, rgba(37,99,235,0) 70%)", animation: "flameFlicker 0.35s infinite ease-in-out" }}
                             />
                             <div
-                              className="absolute bottom-1 left-1/2 -translate-x-1/2 w-4 h-8 rounded-full"
+                              className="absolute bottom-1 left-1/2 -translate-x-1/2 w-[36px] h-[72px] rounded-full"
                               style={{ background: "radial-gradient(ellipse at bottom, rgba(191,219,254,0.95) 0%, rgba(147,197,253,0.6) 60%, rgba(147,197,253,0) 80%)", animation: "flameFlicker 0.3s infinite ease-in-out reverse" }}
                             />
                             <div
-                              className="absolute -bottom-1 left-1/2 -translate-x-1/2 w-20 h-10 rounded-full blur-md opacity-80"
+                              className="absolute -bottom-1 left-1/2 -translate-x-1/2 w-[192px] h-[96px] rounded-full blur-md opacity-80"
                               style={{ background: "radial-gradient(circle, rgba(59,130,246,0.6), rgba(59,130,246,0))" }}
                             />
                           </div>


### PR DESCRIPTION
## Purpose

Based on user feedback, this PR addresses equipment positioning and cleanup requirements for the Lassaigne Test virtual lab. Users requested to reposition the bunsen burner below the organic compound in the equipment section and remove the visual bunsen burner component from the workbench area.

## Code changes

- **Equipment reordering**: Moved bunsen burner item to appear after organic compound in the equipment list in `VirtualLab.tsx`
- **Workbench cleanup**: Removed the entire bunsen burner visual component and blue flame animation from the workbench in `WorkBench.tsx`, including the burner image and flame effects

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 63`

🔗 [Edit in Builder.io](https://builder.io/app/projects/107b32a5657e4dffaa31a807b76bb0f2/vibe-world)

👀 [Preview Link](https://107b32a5657e4dffaa31a807b76bb0f2-vibe-world.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>107b32a5657e4dffaa31a807b76bb0f2</projectId>-->
<!--<branchName>vibe-world</branchName>-->