### PR TITLE
Fix step undo logic and improve Lassaigne/Titration UX

### DIFF
--- a/client/src/experiments/LassaigneTest/components/LassaigneApp.tsx
+++ b/client/src/experiments/LassaigneTest/components/LassaigneApp.tsx
@@ -60,7 +60,7 @@ export default function LassaigneApp({ onBack }: LassaigneAppProps) {
   };
 
   const handleStepUndo = (stepId?: number) => {
-    const target = stepId ?? (mode.currentGuidedStep + 1);
+    const target = stepId ?? (completedSteps.length > 0 ? completedSteps[completedSteps.length - 1] : mode.currentGuidedStep);
     setCompletedSteps(prev => prev.filter(id => id !== target));
     setMode(m => ({ ...m, currentGuidedStep: Math.max(0, m.currentGuidedStep - 1) }));
   };

--- a/client/src/experiments/LassaigneTest/components/VirtualLab.tsx
+++ b/client/src/experiments/LassaigneTest/components/VirtualLab.tsx
@@ -432,7 +432,14 @@ export default function VirtualLab({
 
           <div className="lg:col-span-2 space-y-2">
             <Button
-              onClick={() => onStepUndo()}
+              onClick={() => {
+                if (halide) setHalide(null);
+                else if (interferenceRemoved) setInterferenceRemoved(false);
+                else if (sulphurPositive) setSulphurPositive(null);
+                else if (nitrogenPositive) setNitrogenPositive(false);
+                else if (hasExtract) setHasExtract(false);
+                onStepUndo();
+              }}
               variant="outline"
               className="w-full bg-red-50 border-red-200 text-red-700 hover:bg-red-100"
               disabled={mode.currentGuidedStep <= 0}

--- a/client/src/experiments/LassaigneTest/components/VirtualLab.tsx
+++ b/client/src/experiments/LassaigneTest/components/VirtualLab.tsx
@@ -333,7 +333,15 @@ export default function VirtualLab({
 
               <div className="space-y-2">
                 <Button
-                  onClick={() => onStepUndo()}
+                  onClick={() => {
+                    // Revert latest local change in reverse dependency order
+                    if (halide) setHalide(null);
+                    else if (interferenceRemoved) setInterferenceRemoved(false);
+                    else if (sulphurPositive) setSulphurPositive(null);
+                    else if (nitrogenPositive) setNitrogenPositive(false);
+                    else if (hasExtract) setHasExtract(false);
+                    onStepUndo();
+                  }}
                   variant="outline"
                   className="w-full bg-red-50 border-red-200 text-red-700 hover:bg-red-100"
                   disabled={mode.currentGuidedStep <= 0}

--- a/client/src/experiments/LassaigneTest/components/WorkBench.tsx
+++ b/client/src/experiments/LassaigneTest/components/WorkBench.tsx
@@ -35,10 +35,16 @@ export default function WorkBench({ step, totalSteps, equipmentItems, onNext, on
       const tube = next.find(p => p.id === 'ignition-tube');
       const burner = next.find(p => p.id === 'bunsen-burner');
       if (tube && burner) {
-        const targetY = Math.max(tube.y, burner.y); // align along the lower baseline
+        // Center fusion tube horizontally over the burner and place it just above the burner
+        const tubeWidth = 224; // w-56
+        const tubeHeight = 256; // h-64
+        const burnerWidth = 480; // w-[480px]
+        const alignX = burner.x + (burnerWidth - tubeWidth) / 2;
+        const alignY = burner.y - tubeHeight + 40; // small gap above burner
+
         return next.map(p =>
-          p.id === 'ignition-tube' || p.id === 'bunsen-burner'
-            ? { ...p, y: targetY }
+          p.id === 'ignition-tube'
+            ? { ...p, x: alignX, y: Math.max(16, alignY) }
             : p
         );
       }

--- a/client/src/experiments/LassaigneTest/components/WorkBench.tsx
+++ b/client/src/experiments/LassaigneTest/components/WorkBench.tsx
@@ -18,7 +18,7 @@ interface PrepWorkbenchProps {
 import { useRef, useState } from "react";
 import { TestTube, Beaker, FlaskConical, Droplets, Filter, Flame } from "lucide-react";
 
-export default function WorkBench({ step, totalSteps, equipmentItems }: PrepWorkbenchProps) {
+export default function WorkBench({ step, totalSteps, equipmentItems, onNext, onFinish }: PrepWorkbenchProps) {
   const containerRef = useRef<HTMLDivElement | null>(null);
   const [placed, setPlaced] = useState<Array<{ id: string; x: number; y: number }>>([]);
 
@@ -31,6 +31,21 @@ export default function WorkBench({ step, totalSteps, equipmentItems }: PrepWork
     const x = Math.max(16, Math.min(e.clientX - rect.left - 24, rect.width - 48));
     const y = Math.max(16, Math.min(e.clientY - rect.top - 24, rect.height - 48));
     setPlaced(prev => [...prev, { id: eqId, x, y }]);
+
+    // Auto-progress steps based on expected sequence
+    const sequence = [
+      "ignition-tube",       // Step 1
+      "sodium-piece",        // Step 2
+      "organic-compound",    // Step 3
+      "bunsen-burner",       // Step 4
+      "water-bath",          // Step 5
+      "filter-funnel"        // Step 6
+    ];
+    const expected = sequence[step];
+    if (expected && eqId === expected) {
+      if (step < totalSteps - 1) onNext();
+      else onFinish();
+    }
   };
 
   const handleDragOver = (e: React.DragEvent<HTMLDivElement>) => {

--- a/client/src/experiments/LassaigneTest/components/WorkBench.tsx
+++ b/client/src/experiments/LassaigneTest/components/WorkBench.tsx
@@ -145,7 +145,7 @@ export default function WorkBench({ step, totalSteps, equipmentItems, onNext, on
               style={{ left: p.x, top: p.y }}
             >
               <div className="flex flex-col items-center">
-                <div className={`${p.id === "ignition-tube" ? "w-56 h-64" : p.id === "bunsen-burner" ? "w-24 h-24" : "w-16 h-16"} relative rounded-lg ${p.id === "ignition-tube" || p.id === "bunsen-burner" ? "bg-transparent border-0 shadow-none" : "bg-white border-2 border-blue-200 shadow-sm"} flex items-center justify-center ${colorClass}`}>
+                <div className={`${p.id === "ignition-tube" ? "w-56 h-64" : p.id === "bunsen-burner" ? "w-[480px] h-[480px]" : "w-16 h-16"} relative rounded-lg ${p.id === "ignition-tube" || p.id === "bunsen-burner" ? "bg-transparent border-0 shadow-none" : "bg-white border-2 border-blue-200 shadow-sm"} flex items-center justify-center ${colorClass}`}>
                   {p.id === "ignition-tube" ? (
                     <>
                       <img

--- a/client/src/experiments/LassaigneTest/components/WorkBench.tsx
+++ b/client/src/experiments/LassaigneTest/components/WorkBench.tsx
@@ -145,7 +145,7 @@ export default function WorkBench({ step, totalSteps, equipmentItems, onNext, on
               style={{ left: p.x, top: p.y }}
             >
               <div className="flex flex-col items-center">
-                <div className={`${p.id === "ignition-tube" ? "w-56 h-64" : p.id === "bunsen-burner" ? "w-24 h-24" : "w-16 h-16"} relative rounded-lg bg-white border-2 border-blue-200 shadow-sm flex items-center justify-center ${colorClass}`}>
+                <div className={`${p.id === "ignition-tube" ? "w-56 h-64" : p.id === "bunsen-burner" ? "w-24 h-24" : "w-16 h-16"} relative rounded-lg ${p.id === "ignition-tube" || p.id === "bunsen-burner" ? "bg-transparent border-0 shadow-none" : "bg-white border-2 border-blue-200 shadow-sm"} flex items-center justify-center ${colorClass}`}>
                   {p.id === "ignition-tube" ? (
                     <>
                       <img

--- a/client/src/experiments/LassaigneTest/components/WorkBench.tsx
+++ b/client/src/experiments/LassaigneTest/components/WorkBench.tsx
@@ -35,16 +35,25 @@ export default function WorkBench({ step, totalSteps, equipmentItems, onNext, on
       const tube = next.find(p => p.id === 'ignition-tube');
       const burner = next.find(p => p.id === 'bunsen-burner');
       if (tube && burner) {
-        // Center fusion tube horizontally over the burner and place it just above the burner
+        // Center both items in the middle of workbench with equal space on left and right
         const tubeWidth = 224; // w-56
         const tubeHeight = 256; // h-64
         const burnerWidth = 480; // w-[480px]
-        const alignX = burner.x + (burnerWidth - tubeWidth) / 2;
-        const alignY = burner.y - tubeHeight + 40; // small gap above burner
+        const workbenchWidth = rect.width;
+
+        // Position burner in center of workbench
+        const burnerCenterX = (workbenchWidth - burnerWidth) / 2;
+        const burnerY = Math.max(200, rect.height - 300); // position in lower middle area
+
+        // Center tube above burner
+        const tubeCenterX = burnerCenterX + (burnerWidth - tubeWidth) / 2;
+        const tubeY = Math.max(16, burnerY - tubeHeight + 40); // small gap above burner
 
         return next.map(p =>
-          p.id === 'ignition-tube'
-            ? { ...p, x: alignX, y: Math.max(16, alignY) }
+          p.id === 'bunsen-burner'
+            ? { ...p, x: burnerCenterX, y: burnerY }
+            : p.id === 'ignition-tube'
+            ? { ...p, x: tubeCenterX, y: tubeY }
             : p
         );
       }

--- a/client/src/experiments/LassaigneTest/components/WorkBench.tsx
+++ b/client/src/experiments/LassaigneTest/components/WorkBench.tsx
@@ -30,7 +30,20 @@ export default function WorkBench({ step, totalSteps, equipmentItems, onNext, on
     if (!rect) return;
     const x = Math.max(16, Math.min(e.clientX - rect.left - 24, rect.width - 48));
     const y = Math.max(16, Math.min(e.clientY - rect.top - 24, rect.height - 48));
-    setPlaced(prev => [...prev, { id: eqId, x, y }]);
+    setPlaced(prev => {
+      const next = [...prev, { id: eqId, x, y }];
+      const tube = next.find(p => p.id === 'ignition-tube');
+      const burner = next.find(p => p.id === 'bunsen-burner');
+      if (tube && burner) {
+        const targetY = Math.max(tube.y, burner.y); // align along the lower baseline
+        return next.map(p =>
+          p.id === 'ignition-tube' || p.id === 'bunsen-burner'
+            ? { ...p, y: targetY }
+            : p
+        );
+      }
+      return next;
+    });
 
     // Auto-progress steps based on expected sequence
     const sequence = [

--- a/client/src/experiments/Titration1/components/Equipment.tsx
+++ b/client/src/experiments/Titration1/components/Equipment.tsx
@@ -18,6 +18,7 @@ interface EquipmentProps {
   color?: string;
   volume?: number;
   reading?: number;
+  mixing?: boolean;
 }
 
 export const Equipment: React.FC<EquipmentProps> = ({
@@ -32,7 +33,8 @@ export const Equipment: React.FC<EquipmentProps> = ({
   disabled = false,
   color,
   volume,
-  reading
+  reading,
+  mixing
 }) => {
   const [isDragging, setIsDragging] = React.useState(false);
   const [dragOffset, setDragOffset] = React.useState({ x: 0, y: 0 });
@@ -187,6 +189,15 @@ export const Equipment: React.FC<EquipmentProps> = ({
                   opacity: 0.7
                 }}
               />
+            )}
+            {/* Mixing animation overlay */}
+            {mixing && (
+              <div
+                className="absolute inset-0 flex items-center justify-center pointer-events-none"
+                style={{ clipPath: 'polygon(30% 70%, 70% 70%, 65% 95%, 35% 95%)' }}
+              >
+                <div className="w-10 h-10 rounded-full border-4 border-white/60 border-t-transparent animate-spin"></div>
+              </div>
             )}
           </div>
         ) : (

--- a/client/src/experiments/Titration1/components/VirtualLab.tsx
+++ b/client/src/experiments/Titration1/components/VirtualLab.tsx
@@ -360,11 +360,13 @@ export default function VirtualLab({
       }, ANIMATION.DROPPER_DURATION);
 
     } else if (equipmentId === 'phenolphthalein' && currentStep === 3) {
-      // Add indicator
+      // Add indicator after click with mixing animation and messages
       setActiveEquipment(equipmentId);
-      setShowToast("Adding 2-3 drops of phenolphthalein indicator...");
+      setShowToast("two to three drops of indicator added in the conical flask");
+      setIsMixing(true);
 
       setSafeTimeout(() => {
+        setIsMixing(false);
         setConicalFlask(prev => ({
           ...prev,
           hasIndicator: true
@@ -379,7 +381,7 @@ export default function VirtualLab({
           buretteReading: burette.reading,
           colorBefore: conicalFlask.colorHex,
           colorAfter: conicalFlask.colorHex,
-          observation: 'Added phenolphthalein indicator - solution remains colorless'
+          observation: 'Two to three drops of phenolphthalein added and mixed'
         };
         setTitrationLog(prev => [...prev, logEntry]);
 
@@ -387,7 +389,7 @@ export default function VirtualLab({
         setShowToast("Indicator added - ready for titration!");
         setSafeTimeout(() => setShowToast(""), 2000);
         handleStepComplete();
-      }, 1000);
+      }, ANIMATION.MIXING_DURATION);
 
     } else if (equipmentId === 'naoh-solution' && currentStep === 4) {
       // Fill burette with NaOH

--- a/client/src/experiments/Titration1/components/VirtualLab.tsx
+++ b/client/src/experiments/Titration1/components/VirtualLab.tsx
@@ -67,6 +67,7 @@ export default function VirtualLab({
   const [titrationAction, setTitrationAction] = useState<TitrationAction | null>(null);
   const [titrationLog, setTitrationLog] = useState<TitrationLog[]>([]);
   const [showToast, setShowToast] = useState<string>("");
+  const [isMixing, setIsMixing] = useState(false);
   
   // Workbench state
   const [currentStep, setCurrentStep] = useState(1);

--- a/client/src/experiments/Titration1/components/VirtualLab.tsx
+++ b/client/src/experiments/Titration1/components/VirtualLab.tsx
@@ -283,7 +283,14 @@ export default function VirtualLab({
       const currentStepData = GUIDED_STEPS[currentStep - 1];
       const isPlacementStep = currentStepData.action.includes("Drag");
       const allPresent = currentStepData.equipment.every(id => afterIds.includes(id));
-      if (isPlacementStep && allPresent && !completedSteps.includes(currentStep)) {
+
+      // Step 3 special flow: after placing indicator, prompt user to click it
+      if (currentStep === 3 && equipmentId === 'phenolphthalein') {
+        setTimeout(() => {
+          setShowToast('click on the indicator icon');
+          setSafeTimeout(() => setShowToast(''), 3000);
+        }, 600);
+      } else if (isPlacementStep && allPresent && !completedSteps.includes(currentStep)) {
         setTimeout(() => {
           handleStepComplete();
         }, 600);

--- a/client/src/experiments/Titration1/components/VirtualLab.tsx
+++ b/client/src/experiments/Titration1/components/VirtualLab.tsx
@@ -739,6 +739,7 @@ export default function VirtualLab({
                     color={equipment.id === 'conical-flask' ? conicalFlask.colorHex : undefined}
                     volume={equipment.id === 'conical-flask' ? conicalFlask.volume : equipment.id === 'pipette' ? (plannedOxalicVolume ?? undefined) : undefined}
                     reading={equipment.id === 'burette' ? burette.reading : undefined}
+                    mixing={equipment.id === 'conical-flask' ? isMixing : undefined}
                   />
                 ) : null;
               })}

--- a/client/src/experiments/Titration1/constants.ts
+++ b/client/src/experiments/Titration1/constants.ts
@@ -230,8 +230,8 @@ export const GUIDED_STEPS: GuidedStep[] = [
   {
     id: 3,
     title: "Add Indicator",
-    description: "Add 2-3 drops of phenolphthalein indicator to the oxalic acid solution.",
-    action: "Click phenolphthalein to add indicator",
+    description: "Drag the phenolphthalein to the workbench, then click the indicator to add 2–3 drops.",
+    action: "Drag phenolphthalein to the workbench",
     equipment: ["phenolphthalein"],
     completed: false
   },


### PR DESCRIPTION
## Purpose

The users were working on improving the Lassaigne Test and Titration experiments with several UX enhancements:
- Auto-progression of steps when equipment is placed on the workbench
- Better positioning and alignment of fusion tube and Bunsen burner
- Removing white backgrounds from equipment for cleaner visuals
- Scaling up the Bunsen burner size significantly
- Improving the phenolphthalein indicator workflow with click interactions and mixing animations
- Centering equipment placement with proper spacing

## Code changes

**Lassaigne Test improvements:**
- Fixed step undo logic to properly handle completed steps array instead of using current step + 1
- Added state reversion logic in undo buttons to reset local changes in reverse dependency order
- Implemented auto-step progression when equipment is dropped in correct sequence
- Added automatic alignment logic to center fusion tube above Bunsen burner with equal spacing
- Increased Bunsen burner size from 24x24 to 480x480 pixels
- Removed white backgrounds and borders from fusion tube and Bunsen burner for transparent appearance

**Titration experiment improvements:**
- Updated step 3 description to "Drag phenolphthalein to workbench" workflow
- Added click interaction flow for phenolphthalein indicator with toast messages
- Implemented mixing animation in conical flask after indicator is added
- Added mixing state and animation overlay with spinning border effect
- Updated observation text to reflect the new "two to three drops added and mixed" workflowTo clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 66`

🔗 [Edit in Builder.io](https://builder.io/app/projects/4cfe042bf2e64b198197d41a5cdde6b5/curry-garden)

👀 [Preview Link](https://4cfe042bf2e64b198197d41a5cdde6b5-curry-garden.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>4cfe042bf2e64b198197d41a5cdde6b5</projectId>-->
<!--<branchName>curry-garden</branchName>-->