### PR TITLE
Update lab equipment: rename water bath to china dish

### DIFF
--- a/client/src/experiments/LassaigneTest/components/VirtualLab.tsx
+++ b/client/src/experiments/LassaigneTest/components/VirtualLab.tsx
@@ -73,6 +73,7 @@ export default function VirtualLab({
     { id: "organic-compound", label: "Organic Compound", icon: <FlaskConical className="w-8 h-8 text-purple-600 mb-2" /> },
     { id: "bunsen-burner", label: "Bunsen Burner", icon: <Flame className="w-8 h-8 text-orange-500 mb-2" /> },
     { id: "water-bath", label: "China Dish", icon: <Droplets className="w-8 h-8 text-blue-500 mb-2" /> },
+    { id: "distilled-water", label: "Distilled Water", icon: <Droplets className="w-8 h-8 text-sky-500 mb-2" /> },
     { id: "filter-funnel", label: "Filter Paper & Funnel", icon: <Filter className="w-8 h-8 text-amber-600 mb-2" /> },
   ];
 

--- a/client/src/experiments/LassaigneTest/components/VirtualLab.tsx
+++ b/client/src/experiments/LassaigneTest/components/VirtualLab.tsx
@@ -72,7 +72,7 @@ export default function VirtualLab({
     { id: "sodium-piece", label: "Sodium Piece (under kerosene)", icon: <Beaker className="w-8 h-8 text-emerald-600 mb-2" /> },
     { id: "organic-compound", label: "Organic Compound", icon: <FlaskConical className="w-8 h-8 text-purple-600 mb-2" /> },
     { id: "bunsen-burner", label: "Bunsen Burner", icon: <Flame className="w-8 h-8 text-orange-500 mb-2" /> },
-    { id: "water-bath", label: "Water Bath", icon: <Droplets className="w-8 h-8 text-blue-500 mb-2" /> },
+    { id: "water-bath", label: "China Dish", icon: <Droplets className="w-8 h-8 text-blue-500 mb-2" /> },
     { id: "filter-funnel", label: "Filter Paper & Funnel", icon: <Filter className="w-8 h-8 text-amber-600 mb-2" /> },
   ];
 

--- a/client/src/experiments/LassaigneTest/components/WorkBench.tsx
+++ b/client/src/experiments/LassaigneTest/components/WorkBench.tsx
@@ -413,6 +413,21 @@ export default function WorkBench({ step, totalSteps, equipmentItems, onNext, on
           );
         }
 
+        // Show china dish when water bath is on the bench
+        if (hasWaterBath && waterBath) {
+          const left = waterBath.x + 80;
+          const top = waterBath.y - 20;
+          visuals.push(
+            <img
+              key="china-dish"
+              src="https://cdn.builder.io/api/v1/image/assets%2Fc52292a04d4c4255a87bdaa80a28beb9%2Fa357d1e0379f4f93a6440c08a0713b94?format=webp&width=800"
+              alt="China Dish"
+              className="absolute pointer-events-none drop-shadow-md"
+              style={{ left, top, width: 140, height: 140, objectFit: 'contain' }}
+            />
+          );
+        }
+
         if (hasIgnitionTube && hasBunsenBurner && tube && burner && isHeating) {
           const burnerCenterX = burner.x + 480 / 2;
           const tubeBottomY = tube.y + tubeHeight - 40;

--- a/client/src/experiments/LassaigneTest/components/WorkBench.tsx
+++ b/client/src/experiments/LassaigneTest/components/WorkBench.tsx
@@ -279,6 +279,7 @@ export default function WorkBench({ step, totalSteps, equipmentItems, onNext, on
           if (!item) return null;
           if (p.id === "sodium-piece" && hasIgnitionTube) return null;
           if (p.id === "organic-compound" && hasIgnitionTube) return null;
+          if (p.id === "water-bath") return null; // remove water bath symbol from workbench
           const Icon =
             p.id === "ignition-tube"
               ? TestTube

--- a/client/src/experiments/LassaigneTest/components/WorkBench.tsx
+++ b/client/src/experiments/LassaigneTest/components/WorkBench.tsx
@@ -59,6 +59,23 @@ export default function WorkBench({ step, totalSteps, equipmentItems, onNext, on
   const heatTimerRef = useRef<number | null>(null);
   const [heatProgress, setHeatProgress] = useState(0); // 0 -> 1 while heating
 
+  // Auto-stop heating after 6 seconds when started
+  useEffect(() => {
+    if (isHeating) {
+      if (heatTimerRef.current) clearTimeout(heatTimerRef.current);
+      heatTimerRef.current = window.setTimeout(() => {
+        setIsHeating(false);
+        heatTimerRef.current = null;
+      }, 6000);
+    }
+    return () => {
+      if (!isHeating && heatTimerRef.current) {
+        clearTimeout(heatTimerRef.current);
+        heatTimerRef.current = null;
+      }
+    };
+  }, [isHeating]);
+
   // Smoothly animate heating/cooling progress
   useEffect(() => {
     const tick = () =>
@@ -67,8 +84,8 @@ export default function WorkBench({ step, totalSteps, equipmentItems, onNext, on
         const next = Math.max(0, Math.min(1, p + delta));
         return next;
       });
-    const id = setInterval(tick, 100);
-    return () => clearInterval(id);
+    const id = window.setInterval(tick, 100);
+    return () => window.clearInterval(id);
   }, [isHeating]);
 
   // Derived colors for the organic compound when heating

--- a/client/src/experiments/LassaigneTest/components/WorkBench.tsx
+++ b/client/src/experiments/LassaigneTest/components/WorkBench.tsx
@@ -56,6 +56,7 @@ export default function WorkBench({ step, totalSteps, equipmentItems, onNext, on
   const containerRef = useRef<HTMLDivElement | null>(null);
   const [placed, setPlaced] = useState<Array<{ id: string; x: number; y: number }>>([]);
   const [isHeating, setIsHeating] = useState(false);
+  const heatTimerRef = useRef<number | null>(null);
   const [heatProgress, setHeatProgress] = useState(0); // 0 -> 1 while heating
 
   // Smoothly animate heating/cooling progress

--- a/client/src/experiments/LassaigneTest/components/WorkBench.tsx
+++ b/client/src/experiments/LassaigneTest/components/WorkBench.tsx
@@ -423,8 +423,8 @@ export default function WorkBench({ step, totalSteps, equipmentItems, onNext, on
               key="china-dish"
               src="https://cdn.builder.io/api/v1/image/assets%2Fc52292a04d4c4255a87bdaa80a28beb9%2Fa357d1e0379f4f93a6440c08a0713b94?format=webp&width=800"
               alt="China Dish"
-              className="absolute pointer-events-none drop-shadow-md"
-              style={{ left, top, width: 140, height: 140, objectFit: 'contain' }}
+              className="absolute pointer-events-none drop-shadow-md mix-blend-multiply"
+              style={{ left, top, width: 140, height: 140, objectFit: 'contain', background: 'transparent' }}
             />
           );
         }

--- a/client/src/experiments/LassaigneTest/components/WorkBench.tsx
+++ b/client/src/experiments/LassaigneTest/components/WorkBench.tsx
@@ -267,8 +267,10 @@ export default function WorkBench({ step, totalSteps, equipmentItems, onNext, on
         const hasSodiumPiece = placed.some(p => p.id === "sodium-piece");
         const hasOrganicCompound = placed.some(p => p.id === "organic-compound");
         const hasBunsenBurner = placed.some(p => p.id === "bunsen-burner");
+        const hasWaterBath = placed.some(p => p.id === "water-bath");
         const tube = placed.find(p => p.id === 'ignition-tube');
         const burner = placed.find(p => p.id === 'bunsen-burner');
+        const waterBath = placed.find(p => p.id === 'water-bath');
         const tubeWidth = 224;
         const tubeHeight = 256;
 

--- a/client/src/experiments/LassaigneTest/components/WorkBench.tsx
+++ b/client/src/experiments/LassaigneTest/components/WorkBench.tsx
@@ -382,6 +382,23 @@ export default function WorkBench({ step, totalSteps, equipmentItems, onNext, on
               </div>
             </div>
           );
+
+          // Heat shimmer around tube bottom
+          visuals.push(
+            <div key="tubeGlow" className="absolute pointer-events-none" style={{ left: tube.x + (tubeWidth / 2) - 28, top: tube.y + tubeHeight - 68 }}>
+              <div
+                className="rounded-full"
+                style={{
+                  width: 56,
+                  height: 56,
+                  background: `radial-gradient(circle, rgba(255,99,71,${0.55}) 0%, rgba(255,140,0,0.45) 45%, rgba(255,140,0,0) 70%)`,
+                  filter: "blur(10px)",
+                  opacity: 0.85,
+                  animation: 'flameFlicker 1.2s ease-in-out infinite',
+                }}
+              />
+            </div>
+          );
         }
 
         return (

--- a/client/src/experiments/LassaigneTest/components/WorkBench.tsx
+++ b/client/src/experiments/LassaigneTest/components/WorkBench.tsx
@@ -373,7 +373,19 @@ export default function WorkBench({ step, totalSteps, equipmentItems, onNext, on
                 top: Math.min(Math.max(burnerMouthY, 16), containerH - 60),
               }}
             >
-              <Button onClick={() => setIsHeating(h => !h)} className="bg-red-600 hover:bg-red-700 text-white shadow px-4 py-2 rounded-md">
+              <Button
+                onClick={() => {
+                  setIsHeating((h) => {
+                    const next = !h;
+                    if (!next && heatTimerRef.current) {
+                      clearTimeout(heatTimerRef.current);
+                      heatTimerRef.current = null;
+                    }
+                    return next;
+                  });
+                }}
+                className="bg-red-600 hover:bg-red-700 text-white shadow px-4 py-2 rounded-md"
+              >
                 {isHeating ? "STOP heating" : "START heating"}
               </Button>
             </div>

--- a/client/src/experiments/LassaigneTest/components/WorkBench.tsx
+++ b/client/src/experiments/LassaigneTest/components/WorkBench.tsx
@@ -289,7 +289,7 @@ export default function WorkBench({ step, totalSteps, equipmentItems, onNext, on
               ? Flame
               : p.id === "organic-compound"
               ? FlaskConical
-              : p.id === "water-bath"
+              : p.id === "water-bath" || p.id === "distilled-water"
               ? Droplets
               : Filter;
           const colorClass =
@@ -303,6 +303,8 @@ export default function WorkBench({ step, totalSteps, equipmentItems, onNext, on
               ? "text-purple-600"
               : p.id === "water-bath"
               ? "text-blue-500"
+              : p.id === "distilled-water"
+              ? "text-sky-500"
               : "text-amber-600";
           return (
             <div

--- a/client/src/experiments/LassaigneTest/components/WorkBench.tsx
+++ b/client/src/experiments/LassaigneTest/components/WorkBench.tsx
@@ -297,14 +297,29 @@ export default function WorkBench({ step, totalSteps, equipmentItems, onNext, on
                       {hasOrganicCompound && (
                         <div className="absolute bottom-12 left-[53%] -translate-x-1/2 pointer-events-none">
                           <div className="relative w-[22px] h-[110px] overflow-hidden">
+                            {/* Liquid content with heat-responsive color */}
                             <div
-                              className="absolute bottom-0 left-0 right-0"
+                              className="absolute bottom-0 left-0 right-0 transition-all duration-300"
                               style={{
                                 height: "22%",
-                                background: "linear-gradient(to top, #fde68a, #f59e0b)",
+                                background: `linear-gradient(to top, ${heatedColors.top}, ${heatedColors.bottom})`,
                                 borderTopLeftRadius: 8,
                                 borderTopRightRadius: 8,
                                 opacity: 0.95,
+                                boxShadow: `0 0 ${8 + 24 * heatProgress}px rgba(239,68,68,${0.4 * heatProgress})`,
+                                filter: `saturate(${1 + heatProgress * 0.5}) brightness(${1 + heatProgress * 0.2})`,
+                              }}
+                            />
+                            {/* Red-hot glow at tube tip when heating */}
+                            <div
+                              className="absolute -bottom-3 left-1/2 -translate-x-1/2 rounded-full"
+                              style={{
+                                width: 40,
+                                height: 40,
+                                background: `radial-gradient(circle, rgba(255,80,80,${0.6 * heatProgress}) 0%, rgba(255,140,0,${0.4 * heatProgress}) 40%, rgba(255,140,0,0) 70%)`,
+                                filter: `blur(${6 + 10 * heatProgress}px)`,
+                                opacity: heatProgress,
+                                transition: "opacity 200ms, filter 200ms",
                               }}
                             />
                           </div>

--- a/client/src/experiments/LassaigneTest/components/WorkBench.tsx
+++ b/client/src/experiments/LassaigneTest/components/WorkBench.tsx
@@ -421,9 +421,9 @@ export default function WorkBench({ step, totalSteps, equipmentItems, onNext, on
           visuals.push(
             <img
               key="china-dish"
-              src="https://cdn.builder.io/api/v1/image/assets%2Fc52292a04d4c4255a87bdaa80a28beb9%2Fa357d1e0379f4f93a6440c08a0713b94?format=webp&width=800"
+              src="https://cdn.builder.io/api/v1/image/assets%2Fc52292a04d4c4255a87bdaa80a28beb9%2F21e55328d5ce41dea7cd0cecc3be9548?format=webp&width=800"
               alt="China Dish"
-              className="absolute pointer-events-none drop-shadow-md mix-blend-multiply"
+              className="absolute pointer-events-none drop-shadow-md"
               style={{ left, top, width: 140, height: 140, objectFit: 'contain', background: 'transparent' }}
             />
           );


### PR DESCRIPTION
## Purpose

The user requested several updates to the virtual lab interface to improve the Lassaigne Test experiment simulation:
- Replace "water bath" equipment with "china dish" for more accurate lab terminology
- Add visual china dish image when equipment is placed on workbench
- Enhance heating effects with color changes and visual feedback
- Add new "distilled water" equipment option
- Improve the heating simulation with automatic timing and post-heat color changes

## Code changes

**Equipment Updates:**
- Renamed "Water Bath" to "China Dish" in equipment list
- Added new "Distilled Water" equipment with sky-blue color
- Removed water bath symbol display from workbench when placed

**Visual Enhancements:**
- Added china dish image display when water bath equipment is dropped on workbench
- Implemented heat-responsive color changes for organic compound (yellow → red during heating, dark red after heating stops)
- Added automatic 6-second heating timer with manual stop option
- Enhanced heating effects with glowing animations and heat shimmer around test tube
- Added smooth color interpolation during heating/cooling transitions

**Technical Improvements:**
- Added color interpolation utilities for smooth heating transitions
- Implemented heat progress tracking and post-heated state management
- Added visual effects for tube glow and flame animations during heatingTo clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 72`

🔗 [Edit in Builder.io](https://builder.io/app/projects/62d90960f6484676b28de6ca07708777/pixel-nest)

👀 [Preview Link](https://62d90960f6484676b28de6ca07708777-pixel-nest.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>62d90960f6484676b28de6ca07708777</projectId>-->
<!--<branchName>pixel-nest</branchName>-->