### PR TITLE
Implement functional undo button for lab actions

### DIFF
--- a/client/src/experiments/LassaigneTest/components/VirtualLab.tsx
+++ b/client/src/experiments/LassaigneTest/components/VirtualLab.tsx
@@ -199,6 +199,8 @@ export default function VirtualLab({
     },
   ]), [hasExtract, nitrogenPositive, sulphurPositive, interferenceRemoved, halide, onStepComplete]);
 
+  const prepUndoRef = useRef<(() => void) | null>(null);
+
   return (
     <div className="relative min-h-[70vh] p-6">
       {!experimentStarted && (

--- a/client/src/experiments/LassaigneTest/components/VirtualLab.tsx
+++ b/client/src/experiments/LassaigneTest/components/VirtualLab.tsx
@@ -337,7 +337,10 @@ export default function VirtualLab({
               <div className="space-y-2">
                 <Button
                   onClick={() => {
-                    // Revert latest local change in reverse dependency order
+                    if (!hasExtract && prepUndoRef.current) {
+                      prepUndoRef.current();
+                      return;
+                    }
                     if (halide) setHalide(null);
                     else if (interferenceRemoved) setInterferenceRemoved(false);
                     else if (sulphurPositive) setSulphurPositive(null);
@@ -347,7 +350,6 @@ export default function VirtualLab({
                   }}
                   variant="outline"
                   className="w-full bg-red-50 border-red-200 text-red-700 hover:bg-red-100"
-                  disabled={mode.currentGuidedStep <= 0}
                 >
                   <ArrowLeft className="w-4 h-4 mr-2" /> UNDO
                 </Button>
@@ -371,6 +373,7 @@ export default function VirtualLab({
                 onNext={() => setPrepStep((s) => Math.min(s + 1, preparationSteps.length - 1))}
                 onFinish={finishPreparation}
                 equipmentItems={equipmentItems.map(({ id, label }) => ({ id, label }))}
+                registerUndo={(fn) => { prepUndoRef.current = fn; }}
               />
             </div>
 
@@ -436,6 +439,10 @@ export default function VirtualLab({
           <div className="lg:col-span-2 space-y-2">
             <Button
               onClick={() => {
+                if (!hasExtract && prepUndoRef.current) {
+                  prepUndoRef.current();
+                  return;
+                }
                 if (halide) setHalide(null);
                 else if (interferenceRemoved) setInterferenceRemoved(false);
                 else if (sulphurPositive) setSulphurPositive(null);
@@ -445,7 +452,6 @@ export default function VirtualLab({
               }}
               variant="outline"
               className="w-full bg-red-50 border-red-200 text-red-700 hover:bg-red-100"
-              disabled={mode.currentGuidedStep <= 0}
             >
               <ArrowLeft className="w-4 h-4 mr-2" /> UNDO
             </Button>


### PR DESCRIPTION
## Purpose
The user requested to make the undo button functional so that when pressed, it properly undoes the last action performed in the virtual lab interface.

## Code changes
- **Added undo functionality to WorkBench component**: Implemented history tracking for equipment placement actions using a state array that stores previous placement configurations
- **Integrated undo registration system**: Added `registerUndo` prop to WorkBench component and connected it to VirtualLab parent component via ref
- **Enhanced undo button logic**: Updated undo button click handlers to check for preparation phase and call the appropriate undo function
- **Removed button disabled state**: Removed the disabled condition that was preventing the undo button from being clickable
- **Added history state management**: Equipment placements now save previous state before making changes, enabling proper rollback functionalityTo clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 73`

🔗 [Edit in Builder.io](https://builder.io/app/projects/62d90960f6484676b28de6ca07708777/curry-nest)

👀 [Preview Link](https://62d90960f6484676b28de6ca07708777-curry-nest.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>62d90960f6484676b28de6ca07708777</projectId>-->
<!--<branchName>curry-nest</branchName>-->