### PR TITLE
Improve step 4 alignment and add titration start modal

### DIFF
--- a/client/src/experiments/Titration1/components/Equipment.tsx
+++ b/client/src/experiments/Titration1/components/Equipment.tsx
@@ -3,7 +3,7 @@ import { X } from "lucide-react";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
 
 // Export LAB_EQUIPMENT for use in other components
-export { LAB_EQUIPMENT } from "../constants";
+export { LAB_EQUIPMENT, STEP_4_POSITIONS } from "../constants";
 
 interface EquipmentProps {
   id: string;
@@ -19,6 +19,7 @@ interface EquipmentProps {
   volume?: number;
   reading?: number;
   mixing?: boolean;
+  currentStep?: number;
 }
 
 export const Equipment: React.FC<EquipmentProps> = ({

--- a/client/src/experiments/Titration1/components/Equipment.tsx
+++ b/client/src/experiments/Titration1/components/Equipment.tsx
@@ -180,7 +180,7 @@ export const Equipment: React.FC<EquipmentProps> = ({
           <img
             src="https://cdn.builder.io/api/v1/image/assets%2Fc52292a04d4c4255a87bdaa80a28beb9%2F73ac259c4cb845619a548dafd6799255?format=webp&width=800"
             alt="Burette with NaOH solution"
-            className={`h-96 w-auto object-contain transition-transform duration-200 ${isActive ? 'scale-105' : ''}`}
+            className={`${currentStep >= 4 ? 'h-[500px]' : 'h-96'} w-auto object-contain transition-transform duration-200 ${isActive ? 'scale-105' : ''}`}
             style={{ filter: 'drop-shadow(3px 3px 6px rgba(0,0,0,0.15))' }}
           />
         ) : id === 'conical-flask' && isPositioned ? (

--- a/client/src/experiments/Titration1/components/Equipment.tsx
+++ b/client/src/experiments/Titration1/components/Equipment.tsx
@@ -35,7 +35,8 @@ export const Equipment: React.FC<EquipmentProps> = ({
   color,
   volume,
   reading,
-  mixing
+  mixing,
+  currentStep = 1
 }) => {
   const [isDragging, setIsDragging] = React.useState(false);
   const [dragOffset, setDragOffset] = React.useState({ x: 0, y: 0 });

--- a/client/src/experiments/Titration1/components/VirtualLab.tsx
+++ b/client/src/experiments/Titration1/components/VirtualLab.tsx
@@ -671,10 +671,12 @@ export default function VirtualLab({
               <p className="text-sm text-gray-600 mb-2">
                 {currentStep === 4 ? "burette already filled with NaOH, Start the titration!" : currentStepData.description}
               </p>
-              <div className="inline-flex items-center px-3 py-1 bg-blue-100 text-blue-700 rounded-full text-xs font-medium">
-                <ArrowRight className="w-3 h-3 mr-1" />
-                {currentStepData.action}
-              </div>
+              {currentStep !== 4 && (
+                <div className="inline-flex items-center px-3 py-1 bg-blue-100 text-blue-700 rounded-full text-xs font-medium">
+                  <ArrowRight className="w-3 h-3 mr-1" />
+                  {currentStepData.action}
+                </div>
+              )}
             </div>
           </div>
         </div>

--- a/client/src/experiments/Titration1/components/VirtualLab.tsx
+++ b/client/src/experiments/Titration1/components/VirtualLab.tsx
@@ -941,13 +941,30 @@ export default function VirtualLab({
 
         {/* Start Titration Prompt (shown at beginning of step 4) */}
         <Dialog open={showStartTitrationModal} onOpenChange={setShowStartTitrationModal}>
-          <DialogContent className="max-w-sm">
-            <DialogHeader>
-              <DialogTitle className="text-lg font-semibold">Let's start the titration now!</DialogTitle>
-              <DialogDescription>are you excited?</DialogDescription>
-            </DialogHeader>
-            <div className="mt-4 flex justify-end">
-              <Button onClick={() => setShowStartTitrationModal(false)} className="bg-blue-500 text-white">yes I am!</Button>
+          <DialogContent className="max-w-md w-full p-0 rounded-xl overflow-hidden">
+            <div className="bg-gradient-to-br from-blue-600 to-purple-600 p-6">
+              <div className="flex items-start space-x-4">
+                <div className="bg-white/20 p-3 rounded-lg">
+                  <Droplets className="w-7 h-7 text-white" />
+                </div>
+                <div>
+                  <h3 className="text-white text-2xl font-extrabold">Let's start the titration now!</h3>
+                  <p className="text-blue-100 mt-1">Are you excited?</p>
+                </div>
+              </div>
+            </div>
+
+            <div className="p-6 bg-white">
+              <p className="text-sm text-gray-700">The burette has been aligned and is ready with NaOH. When you're ready, start adding NaOH to the conical flask to begin the titration.</p>
+
+              <div className="mt-6 flex justify-end">
+                <Button
+                  onClick={() => setShowStartTitrationModal(false)}
+                  className="bg-gradient-to-r from-blue-600 to-purple-600 text-white px-5 py-2 rounded-md shadow-md"
+                >
+                  Yes, I am!
+                </Button>
+              </div>
             </div>
           </DialogContent>
         </Dialog>

--- a/client/src/experiments/Titration1/components/VirtualLab.tsx
+++ b/client/src/experiments/Titration1/components/VirtualLab.tsx
@@ -425,16 +425,10 @@ export default function VirtualLab({
         };
         setTitrationLog(prev => [...prev, logEntry]);
 
-        // Automatically remove phenolphthalein and pipette from workbench
-        setEquipmentOnBench(prev => prev.filter(eq => eq.id !== 'phenolphthalein' && eq.id !== 'pipette'));
-        setShowToast("Pipette and phenolphthalein removed from workbench");
-
-        setSafeTimeout(() => {
-          setActiveEquipment("");
-          setShowToast("Burette ready - begin titration!");
-          setSafeTimeout(() => setShowToast(""), 2000);
-          handleStepComplete();
-        }, 1000);
+        setActiveEquipment("");
+        setShowToast("Burette ready - begin titration!");
+        setSafeTimeout(() => setShowToast(""), 2000);
+        handleStepComplete();
       }, 2000);
 
     } else if (equipmentId === 'burette' && currentStep === 5) {

--- a/client/src/experiments/Titration1/components/VirtualLab.tsx
+++ b/client/src/experiments/Titration1/components/VirtualLab.tsx
@@ -167,6 +167,20 @@ export default function VirtualLab({
     }
   }, [showResultsModal, setIsRunning]);
 
+  // Auto-remove phenolphthalein and pipette when step 4 begins
+  useEffect(() => {
+    if (currentStep === 4) {
+      setEquipmentOnBench(prev => {
+        const filtered = prev.filter(eq => eq.id !== 'phenolphthalein' && eq.id !== 'pipette');
+        if (filtered.length !== prev.length) {
+          setShowToast("Pipette and phenolphthalein automatically removed from workbench");
+          setSafeTimeout(() => setShowToast(""), 3000);
+        }
+        return filtered;
+      });
+    }
+  }, [currentStep, setSafeTimeout]);
+
   // Handle color transitions for endpoint detection
   const animateColorTransition = useCallback((fromColor: string, toColor: string, newPhase: TitrationState['currentPhase']) => {
     setColorTransition({

--- a/client/src/experiments/Titration1/components/VirtualLab.tsx
+++ b/client/src/experiments/Titration1/components/VirtualLab.tsx
@@ -7,14 +7,15 @@ import { FlaskConical, Beaker, Droplets, Info, ArrowRight, ArrowLeft, CheckCircl
 import { Link } from "wouter";
 import WorkBench from "./WorkBench";
 import Equipment, { LAB_EQUIPMENT } from "./Equipment";
-import { 
-  COLORS, 
-  INITIAL_FLASK, 
+import {
+  COLORS,
+  INITIAL_FLASK,
   INITIAL_BURETTE,
   GUIDED_STEPS,
   ANIMATION,
   ENDPOINT_COLORS,
   EQUIPMENT_POSITIONS,
+  STEP_4_POSITIONS,
   TITRATION_FORMULAS
 } from "../constants";
 import { 

--- a/client/src/experiments/Titration1/components/VirtualLab.tsx
+++ b/client/src/experiments/Titration1/components/VirtualLab.tsx
@@ -669,7 +669,7 @@ export default function VirtualLab({
                 {currentStepData.title}
               </h4>
               <p className="text-sm text-gray-600 mb-2">
-                {currentStepData.description}
+                {currentStep === 4 ? "burette already filled with NaOH, Start the titration!" : currentStepData.description}
               </p>
               <div className="inline-flex items-center px-3 py-1 bg-blue-100 text-blue-700 rounded-full text-xs font-medium">
                 <ArrowRight className="w-3 h-3 mr-1" />

--- a/client/src/experiments/Titration1/components/VirtualLab.tsx
+++ b/client/src/experiments/Titration1/components/VirtualLab.tsx
@@ -172,11 +172,24 @@ export default function VirtualLab({
     if (currentStep === 4) {
       setEquipmentOnBench(prev => {
         const filtered = prev.filter(eq => eq.id !== 'phenolphthalein' && eq.id !== 'pipette');
+
+        // Reposition burette and conical flask for better alignment in step 4
+        const repositioned = filtered.map(eq => {
+          if (eq.id === 'burette') {
+            return { ...eq, position: { x: 100, y: 20 } };
+          }
+          if (eq.id === 'conical-flask') {
+            return { ...eq, position: { x: 200, y: 320 } };
+          }
+          return eq;
+        });
+
         if (filtered.length !== prev.length) {
           setShowToast("Pipette and phenolphthalein automatically removed from workbench");
           setSafeTimeout(() => setShowToast(""), 3000);
         }
-        return filtered;
+
+        return repositioned;
       });
     }
   }, [currentStep, setSafeTimeout]);

--- a/client/src/experiments/Titration1/components/VirtualLab.tsx
+++ b/client/src/experiments/Titration1/components/VirtualLab.tsx
@@ -939,6 +939,19 @@ export default function VirtualLab({
           </div>
         )}
 
+        {/* Start Titration Prompt (shown at beginning of step 4) */}
+        <Dialog open={showStartTitrationModal} onOpenChange={setShowStartTitrationModal}>
+          <DialogContent className="max-w-sm">
+            <DialogHeader>
+              <DialogTitle className="text-lg font-semibold">Let's start the titration now!</DialogTitle>
+              <DialogDescription>are you excited?</DialogDescription>
+            </DialogHeader>
+            <div className="mt-4 flex justify-end">
+              <Button onClick={() => setShowStartTitrationModal(false)} className="bg-blue-500 text-white">yes I am!</Button>
+            </div>
+          </DialogContent>
+        </Dialog>
+
         {/* Results Analysis Modal */}
         <Dialog open={showResultsModal} onOpenChange={setShowResultsModal}>
           <DialogContent className="max-w-4xl max-h-[90vh] overflow-y-auto">

--- a/client/src/experiments/Titration1/components/VirtualLab.tsx
+++ b/client/src/experiments/Titration1/components/VirtualLab.tsx
@@ -425,10 +425,16 @@ export default function VirtualLab({
         };
         setTitrationLog(prev => [...prev, logEntry]);
 
-        setActiveEquipment("");
-        setShowToast("Burette ready - begin titration!");
-        setSafeTimeout(() => setShowToast(""), 2000);
-        handleStepComplete();
+        // Automatically remove phenolphthalein and pipette from workbench
+        setEquipmentOnBench(prev => prev.filter(eq => eq.id !== 'phenolphthalein' && eq.id !== 'pipette'));
+        setShowToast("Pipette and phenolphthalein removed from workbench");
+
+        setSafeTimeout(() => {
+          setActiveEquipment("");
+          setShowToast("Burette ready - begin titration!");
+          setSafeTimeout(() => setShowToast(""), 2000);
+          handleStepComplete();
+        }, 1000);
       }, 2000);
 
     } else if (equipmentId === 'burette' && currentStep === 5) {

--- a/client/src/experiments/Titration1/components/VirtualLab.tsx
+++ b/client/src/experiments/Titration1/components/VirtualLab.tsx
@@ -176,11 +176,11 @@ export default function VirtualLab({
 
         // Reposition burette and conical flask for better alignment in step 4
         const repositioned = filtered.map(eq => {
-          if (eq.id === 'burette') {
-            return { ...eq, position: { x: 100, y: 20 } };
+          if (eq.id === 'burette' && STEP_4_POSITIONS.burette) {
+            return { ...eq, position: STEP_4_POSITIONS.burette };
           }
-          if (eq.id === 'conical-flask') {
-            return { ...eq, position: { x: 200, y: 320 } };
+          if (eq.id === 'conical-flask' && STEP_4_POSITIONS['conical-flask']) {
+            return { ...eq, position: STEP_4_POSITIONS['conical-flask'] };
           }
           return eq;
         });

--- a/client/src/experiments/Titration1/components/VirtualLab.tsx
+++ b/client/src/experiments/Titration1/components/VirtualLab.tsx
@@ -168,6 +168,9 @@ export default function VirtualLab({
     }
   }, [showResultsModal, setIsRunning]);
 
+  const [showStartTitrationModal, setShowStartTitrationModal] = useState(false);
+  const [startTitrationPromptShown, setStartTitrationPromptShown] = useState(false);
+
   // Auto-remove phenolphthalein and pipette when step 4 begins
   useEffect(() => {
     if (currentStep === 4) {
@@ -192,8 +195,14 @@ export default function VirtualLab({
 
         return repositioned;
       });
+
+      if (!startTitrationPromptShown) {
+        // show modal shortly after repositioning
+        setStartTitrationPromptShown(true);
+        setSafeTimeout(() => setShowStartTitrationModal(true), 600);
+      }
     }
-  }, [currentStep, setSafeTimeout]);
+  }, [currentStep, setSafeTimeout, startTitrationPromptShown]);
 
   // Handle color transitions for endpoint detection
   const animateColorTransition = useCallback((fromColor: string, toColor: string, newPhase: TitrationState['currentPhase']) => {

--- a/client/src/experiments/Titration1/components/VirtualLab.tsx
+++ b/client/src/experiments/Titration1/components/VirtualLab.tsx
@@ -757,6 +757,7 @@ export default function VirtualLab({
                     volume={equipment.id === 'conical-flask' ? conicalFlask.volume : equipment.id === 'pipette' ? (plannedOxalicVolume ?? undefined) : undefined}
                     reading={equipment.id === 'burette' ? burette.reading : undefined}
                     mixing={equipment.id === 'conical-flask' ? isMixing : undefined}
+                    currentStep={currentStep}
                   />
                 ) : null;
               })}

--- a/client/src/experiments/Titration1/constants.ts
+++ b/client/src/experiments/Titration1/constants.ts
@@ -312,6 +312,6 @@ export const EQUIPMENT_POSITIONS = {
 
 // Step 4 specific positioning for better alignment
 export const STEP_4_POSITIONS = {
-  'burette': { x: 80, y: 20 },
-  'conical-flask': { x: 140, y: 380 }
+  'burette': { x: 80, y: 60 },
+  'conical-flask': { x: 140, y: 420 }
 };

--- a/client/src/experiments/Titration1/constants.ts
+++ b/client/src/experiments/Titration1/constants.ts
@@ -239,7 +239,7 @@ export const GUIDED_STEPS: GuidedStep[] = [
     id: 4,
     title: "Fill Burette",
     description: "Fill the burette with NaOH solution and adjust to zero reading.",
-    action: "Click NaOH to fill burette",
+    action: "burette already filled with NaOH, Start the titration!",
     equipment: ["naoh-solution"],
     completed: false
   },

--- a/client/src/experiments/Titration1/constants.ts
+++ b/client/src/experiments/Titration1/constants.ts
@@ -312,6 +312,6 @@ export const EQUIPMENT_POSITIONS = {
 
 // Step 4 specific positioning for better alignment
 export const STEP_4_POSITIONS = {
-  'burette': { x: 80, y: 60 },
-  'conical-flask': { x: 140, y: 420 }
+  'burette': { x: 80, y: 100 },
+  'conical-flask': { x: 140, y: 460 }
 };

--- a/client/src/experiments/Titration1/constants.ts
+++ b/client/src/experiments/Titration1/constants.ts
@@ -238,7 +238,7 @@ export const GUIDED_STEPS: GuidedStep[] = [
   {
     id: 4,
     title: "Fill Burette",
-    description: "Fill the burette with NaOH solution and adjust to zero reading.",
+    description: "burette already filled with NaOH, Start the titration!",
     action: "burette already filled with NaOH, Start the titration!",
     equipment: ["naoh-solution"],
     completed: false

--- a/client/src/experiments/Titration1/constants.ts
+++ b/client/src/experiments/Titration1/constants.ts
@@ -309,3 +309,9 @@ export const EQUIPMENT_POSITIONS = {
   'naoh-solution': { x: 80, y: 300 },
   'phenolphthalein': { x: 80, y: 380 }
 };
+
+// Step 4 specific positioning for better alignment
+export const STEP_4_POSITIONS = {
+  'burette': { x: 100, y: 20 },
+  'conical-flask': { x: 200, y: 320 }
+};

--- a/client/src/experiments/Titration1/constants.ts
+++ b/client/src/experiments/Titration1/constants.ts
@@ -312,6 +312,6 @@ export const EQUIPMENT_POSITIONS = {
 
 // Step 4 specific positioning for better alignment
 export const STEP_4_POSITIONS = {
-  'burette': { x: 100, y: 20 },
-  'conical-flask': { x: 200, y: 320 }
+  'burette': { x: 80, y: 20 },
+  'conical-flask': { x: 140, y: 380 }
 };


### PR DESCRIPTION
## Purpose

Based on user feedback, this PR addresses several UI/UX improvements for the titration experiment's step 4:
- Fix equipment alignment issues that were causing visual problems
- Update step 4 messaging to reflect that the burette is pre-filled
- Add an engaging modal popup to enhance user experience when starting the titration
- Remove unnecessary UI elements (blue line) and improve overall visual design

## Code changes

**Equipment positioning and sizing:**
- Added `STEP_4_POSITIONS` constant for better burette and conical flask alignment in step 4
- Implemented dynamic burette height scaling (500px vs 396px) based on current step
- Auto-repositioning of equipment when step 4 begins

**Step 4 messaging updates:**
- Changed step 4 description from "Fill the burette with NaOH solution and adjust to zero reading" to "burette already filled with NaOH, Start the titration!"
- Removed the action button display for step 4 to eliminate the blue line

**New titration start modal:**
- Added attractive gradient-styled modal with "Let's start the titration now! are you excited?" message
- Includes "Yes I am!" confirmation button
- Auto-triggers after equipment repositioning in step 4
- Enhanced visual design with proper spacing, colors, and icons

**Equipment management:**
- Auto-removal of pipette and phenolphthalein when step 4 begins
- Added `currentStep` prop to Equipment component for step-aware renderingTo clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 74`

🔗 [Edit in Builder.io](https://builder.io/app/projects/62d90960f6484676b28de6ca07708777/flare-space)

👀 [Preview Link](https://62d90960f6484676b28de6ca07708777-flare-space.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>62d90960f6484676b28de6ca07708777</projectId>-->
<!--<branchName>flare-space</branchName>-->