### PR TITLE
Adjust lab equipment positioning and flame placement

### DIFF
--- a/client/src/experiments/LassaigneTest/components/WorkBench.tsx
+++ b/client/src/experiments/LassaigneTest/components/WorkBench.tsx
@@ -453,8 +453,9 @@ export default function WorkBench({ step, totalSteps, equipmentItems, onNext, on
           const flameX = burnerCenterX - 24; // align with burner hole
           const minY = burnerMouthY - 24; // keep near but above burner mouth
           const targetBelowTube = tubeBottomY - 26; // keep a safe gap below the tube
-          const targetAboveMouth = burnerMouthY - 12; // place flame just above burner mouth
-          const desiredY = Math.min(targetBelowTube, targetAboveMouth);
+          const targetAboveMouth = burnerMouthY - 12; // top boundary near burner mouth
+          const midGapY = (targetBelowTube + targetAboveMouth) / 2; // midpoint between tube and burner
+          const desiredY = Math.min(targetBelowTube, Math.max(targetAboveMouth, midGapY));
           const flameY = Math.max(minY, desiredY);
           visuals.push(
             <div key="flame" className="absolute pointer-events-none" style={{ left: flameX, top: flameY }}>


### PR DESCRIPTION
## Purpose
The user requested several positioning adjustments to improve the layout of lab equipment in the Lassaigne Test experiment. The goal was to move equipment upward to utilize empty space on the workbench, increase spacing between components for better visibility, and optimize flame positioning for a more realistic experimental setup.

## Code changes
- **Increased equipment spacing**: Updated `TUBE_BURNER_GAP` from 60 to 160 pixels to double the space between fusion tube and bunsen burner
- **Moved bunsen burner upward**: Adjusted Y position by 80 pixels (from -180 to -260) to utilize empty workbench space
- **Optimized flame positioning**: Modified flame calculation logic to position the flame in the middle gap between the fusion tube and bunsen burner, with improved boundary constraints for more realistic placementTo clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 76`

🔗 [Edit in Builder.io](https://builder.io/app/projects/3c0b4c9daae44dbcbb3d166d53d6df75/swoosh-sanctuary)

👀 [Preview Link](https://3c0b4c9daae44dbcbb3d166d53d6df75-swoosh-sanctuary.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>3c0b4c9daae44dbcbb3d166d53d6df75</projectId>-->
<!--<branchName>swoosh-sanctuary</branchName>-->