### PR TITLE
Position china dish below fusion tube in workbench

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -6,15 +6,15 @@ import { TooltipProvider } from "@/components/ui/tooltip";
 import Home from "@/pages/home";
 import Experiment from "@/pages/experiment";
 import NotFound from "@/pages/not-found";
-import { Route as WRoute, Switch } from "wouter";
+import * as Wouter from "wouter";
 
 function Router() {
   return (
-    <Switch>
-      <WRoute path="/" component={Home} />
-      <WRoute path="/experiment/:id" component={Experiment} />
-      <WRoute component={NotFound} />
-    </Switch>
+    <Wouter.Switch>
+      <Wouter.Route path="/" component={Home} />
+      <Wouter.Route path="/experiment/:id" component={Experiment} />
+      <Wouter.Route component={NotFound} />
+    </Wouter.Switch>
   );
 }
 

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -6,14 +6,14 @@ import { TooltipProvider } from "@/components/ui/tooltip";
 import Home from "@/pages/home";
 import Experiment from "@/pages/experiment";
 import NotFound from "@/pages/not-found";
-import { Route, Switch } from "wouter";
+import { Route as WRoute, Switch } from "wouter";
 
 function Router() {
   return (
     <Switch>
-      <Route path="/" component={Home} />
-      <Route path="/experiment/:id" component={Experiment} />
-      <Route component={NotFound} />
+      <WRoute path="/" component={Home} />
+      <WRoute path="/experiment/:id" component={Experiment} />
+      <WRoute component={NotFound} />
     </Switch>
   );
 }

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -6,6 +6,7 @@ import { TooltipProvider } from "@/components/ui/tooltip";
 import Home from "@/pages/home";
 import Experiment from "@/pages/experiment";
 import NotFound from "@/pages/not-found";
+import { Route, Switch } from "wouter";
 
 function Router() {
   return (

--- a/client/src/experiments/LassaigneTest/components/WorkBench.tsx
+++ b/client/src/experiments/LassaigneTest/components/WorkBench.tsx
@@ -445,6 +445,7 @@ export default function WorkBench({ step, totalSteps, equipmentItems, onNext, on
         if (hasWaterBath && waterBath) {
           const left = waterBath.x + 80;
           const top = waterBath.y - 20;
+          // Dish image
           visuals.push(
             <img
               key="china-dish"
@@ -454,6 +455,38 @@ export default function WorkBench({ step, totalSteps, equipmentItems, onNext, on
               style={{ left, top, width: 140, height: 140, objectFit: 'contain', background: 'transparent' }}
             />
           );
+
+          // If distilled water is present, show water inside the dish
+          const hasDistilled = placed.some(p => p.id === "distilled-water");
+          if (hasDistilled) {
+            const waterLeft = left + 22;
+            const waterTop = top + 82;
+            visuals.push(
+              <div
+                key="china-dish-water"
+                className="absolute pointer-events-none"
+                style={{ left: waterLeft, top: waterTop, width: 96, height: 36 }}
+              >
+                <div
+                  className="w-full h-full rounded-full"
+                  style={{
+                    background:
+                      "radial-gradient(ellipse at 50% 40%, rgba(147, 197, 253, 0.95) 0%, rgba(96, 165, 250, 0.85) 45%, rgba(59, 130, 246, 0.75) 70%, rgba(59, 130, 246, 0.0) 100%)",
+                    boxShadow:
+                      "inset 0 2px 6px rgba(255,255,255,0.8), inset 0 -4px 8px rgba(37,99,235,0.25)",
+                    filter: "saturate(1.1)",
+                  }}
+                />
+                <div
+                  className="absolute left-1/2 -translate-x-1/2 top-1 h-1/2 w-4/5 rounded-full opacity-60"
+                  style={{
+                    background:
+                      "linear-gradient(to bottom, rgba(255,255,255,0.55), rgba(255,255,255,0))",
+                  }}
+                />
+              </div>
+            );
+          }
         }
 
         if (hasIgnitionTube && hasBunsenBurner && tube && burner && isHeating) {

--- a/client/src/experiments/LassaigneTest/components/WorkBench.tsx
+++ b/client/src/experiments/LassaigneTest/components/WorkBench.tsx
@@ -180,10 +180,9 @@ export default function WorkBench({ step, totalSteps, equipmentItems, onNext, on
           const tube = current.find((p) => p.id === "ignition-tube");
           if (tube) {
             const dishWidth = 140;
-            const tubeWidth = 224;
-            const desiredLeft = tube.x + tubeWidth / 2 - dishWidth / 2;
+            const desiredLeft = tube.x + tubeSize.w / 2 - dishWidth / 2;
             const x = clampX(desiredLeft - 80);
-            const y = clampY(tube.y + tubeWidth /* approximate height offset */ + 10);
+            const y = clampY(tube.y + tubeSize.h + 10);
             return { x, y };
           }
           return { x: clampX(32), y: clampY(r.height - 180) };

--- a/client/src/experiments/LassaigneTest/components/WorkBench.tsx
+++ b/client/src/experiments/LassaigneTest/components/WorkBench.tsx
@@ -177,6 +177,15 @@ export default function WorkBench({ step, totalSteps, equipmentItems, onNext, on
           return { x: clampX(r.width - 120), y: clampY(120) };
         }
         case "water-bath": {
+          const tube = current.find((p) => p.id === "ignition-tube");
+          if (tube) {
+            const dishWidth = 140;
+            const tubeWidth = 224;
+            const desiredLeft = tube.x + tubeWidth / 2 - dishWidth / 2;
+            const x = clampX(desiredLeft - 80);
+            const y = clampY(tube.y + tubeWidth /* approximate height offset */ + 10);
+            return { x, y };
+          }
           return { x: clampX(32), y: clampY(r.height - 180) };
         }
         case "filter-funnel": {


### PR DESCRIPTION
## Purpose
Position the china dish component to automatically appear just below the fusion tube when dropped onto the workbench, improving the laboratory experiment workflow and component placement.

## Code changes
- **Router updates**: Added explicit Wouter namespace imports and updated Route/Switch components to use namespaced syntax
- **WorkBench positioning logic**: Enhanced the water-bath case in the positioning logic to detect when an ignition tube is present and automatically position the china dish below it with proper spacing and centering
- **Dynamic positioning**: Implemented calculations to center the dish horizontally relative to the tube and position it 10px below with appropriate boundary clampingTo clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 80`

🔗 [Edit in Builder.io](https://builder.io/app/projects/d8faa420862f4ed1ab75639a3de91c56/spark-forge)

👀 [Preview Link](https://d8faa420862f4ed1ab75639a3de91c56-spark-forge.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>d8faa420862f4ed1ab75639a3de91c56</projectId>-->
<!--<branchName>spark-forge</branchName>-->