### PR TITLE
Add break fusion tube button with animation and resize dish

### DIFF
--- a/client/src/experiments/LassaigneTest/components/WorkBench.tsx
+++ b/client/src/experiments/LassaigneTest/components/WorkBench.tsx
@@ -447,7 +447,7 @@ export default function WorkBench({ step, totalSteps, equipmentItems, onNext, on
         // Show china dish when water bath is on the bench
         if (hasWaterBath && waterBath) {
           // Prefer positioning directly under the fusion tube in the empty space
-          const dishSize = { w: 140, h: 140 };
+          const dishSize = { w: 238, h: 238 };
           const left = tube ? (tube.x + (tubeWidth - dishSize.w) / 2) : (waterBath.x + 80);
           const top = tube ? (tube.y + tubeHeight + 12) : (waterBath.y - 20);
           visuals.push(


### PR DESCRIPTION
## Purpose
The user requested to add interactive functionality to break the fusion tube with visual feedback, and to increase the china dish size for better visibility. This enhances the experiment simulation by allowing users to break the fusion tube and see realistic breaking animation with glass shards falling into the enlarged china dish.

## Code changes
- **Added break fusion tube button**: Red "BREAK FUSION TUBE" button positioned beside the china dish
- **Implemented breaking animation**: Tube falls and rotates into the dish with smooth transitions
- **Added glass shard effects**: 8 animated glass fragments appear when tube breaks with ripple effect
- **Increased china dish size**: Scaled from 140x140 to 238x238 pixels (1.7x increase)
- **Added animation state management**: New state variables for breaking, broken, hidden tube, and animated tube position
- **Enhanced visual feedback**: CSS keyframes for shard dropping and ripple animations
- **Reset functionality**: Breaking state resets when undo is triggeredTo clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 81`

🔗 [Edit in Builder.io](https://builder.io/app/projects/db0bd4906eb44597a1d6b746decfc060/cosmos-sanctuary)

👀 [Preview Link](https://db0bd4906eb44597a1d6b746decfc060-cosmos-sanctuary.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>db0bd4906eb44597a1d6b746decfc060</projectId>-->
<!--<branchName>cosmos-sanctuary</branchName>-->