### PR TITLE
Add titration results page with live data entry

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -6,6 +6,7 @@ import { TooltipProvider } from "@/components/ui/tooltip";
 import Home from "@/pages/home";
 import Experiment from "@/pages/experiment";
 import NotFound from "@/pages/not-found";
+import TitrationResultsPage from "@/pages/titration-results";
 
 function Router() {
   return (

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -11,6 +11,7 @@ function Router() {
   return (
     <Switch>
       <Route path="/" component={Home} />
+      <Route path="/experiment/:id/results" component={require("@/pages/titration-results").default} />
       <Route path="/experiment/:id" component={Experiment} />
       <Route component={NotFound} />
     </Switch>

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -12,7 +12,7 @@ function Router() {
   return (
     <Switch>
       <Route path="/" component={Home} />
-      <Route path="/experiment/:id/results" component={require("@/pages/titration-results").default} />
+      <Route path="/experiment/:id/results" component={TitrationResultsPage} />
       <Route path="/experiment/:id" component={Experiment} />
       <Route component={NotFound} />
     </Switch>

--- a/client/src/experiments/Titration1/components/Titration1App.tsx
+++ b/client/src/experiments/Titration1/components/Titration1App.tsx
@@ -290,6 +290,7 @@ export default function Titration1App({
                 onReset={handleReset}
                 completedSteps={completedSteps}
                 burettePreparationComplete={burettePreparationComplete}
+                experimentId={experimentId}
               />
             </CardContent>
           </Card>

--- a/client/src/experiments/Titration1/components/VirtualLab.tsx
+++ b/client/src/experiments/Titration1/components/VirtualLab.tsx
@@ -751,7 +751,7 @@ export default function VirtualLab({
               </h3>
               
               <div className="space-y-3">
-                {LAB_EQUIPMENT.map((equipment) => (
+                {LAB_EQUIPMENT.filter(eq => !['funnel','wash-bottle','oxalic-acid','naoh-solution'].includes(eq.id)).map((equipment) => (
                   <Equipment
                     key={equipment.id}
                     id={equipment.id}

--- a/client/src/experiments/Titration1/components/VirtualLab.tsx
+++ b/client/src/experiments/Titration1/components/VirtualLab.tsx
@@ -782,7 +782,7 @@ export default function VirtualLab({
               <h4 className="text-sm font-semibold text-gray-700 mb-3">Chemical Reaction</h4>
               <div className="text-center text-xs font-mono leading-relaxed bg-gray-50 rounded-lg p-3 border">
                 <div className="mb-2">
-                  H₂C₂O₄ + 2NaOH → Na₂C₂O₄ + 2H₂O
+                  H₂C₂O₄ + 2NaOH → Na���C₂O₄ + 2H₂O
                 </div>
                 <div className="text-gray-500">
                   Oxalic acid + Sodium hydroxide
@@ -898,6 +898,122 @@ export default function VirtualLab({
 
           {/* Analysis Panel - Right */}
           <div className="lg:col-span-3 space-y-4">
+            {experimentCompleted && (
+              <div className="bg-white/90 backdrop-blur-sm rounded-xl p-4 border border-gray-200 shadow-sm">
+                <h3 className="text-lg font-semibold text-gray-800 mb-4">Live Data Entry</h3>
+
+                <div className="grid grid-cols-2 gap-4 mb-4">
+                  <div>
+                    <label className="block text-xs text-gray-600 mb-1">Oxalic Acid Normality (N₁)</label>
+                    <input
+                      type="number"
+                      inputMode="decimal"
+                      value={acidNormality as any}
+                      onChange={(e) => {
+                        const v = e.target.value;
+                        setAcidNormality(v === "" ? "" : Number(v));
+                      }}
+                      className="w-full border rounded px-3 py-2 text-sm"
+                    />
+                  </div>
+                  <div>
+                    <label className="block text-xs text-gray-600 mb-1">Oxalic Acid Volume (V₁, mL)</label>
+                    <input
+                      type="number"
+                      inputMode="decimal"
+                      value={acidVolume as any}
+                      onChange={(e) => {
+                        const v = e.target.value;
+                        setAcidVolume(v === "" ? "" : Number(v));
+                      }}
+                      className="w-full border rounded px-3 py-2 text-sm"
+                    />
+                  </div>
+                </div>
+
+                <div className="overflow-x-auto">
+                  <table className="min-w-full text-sm">
+                    <thead>
+                      <tr className="text-left text-gray-600">
+                        <th className="py-2 pr-4">Trial</th>
+                        <th className="py-2 pr-4">Initial (mL)</th>
+                        <th className="py-2 pr-4">Final (mL)</th>
+                        <th className="py-2 pr-4">NaOH Used (mL)</th>
+                        <th className="py-2"></th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      {userTrials.map((t, idx) => {
+                        const vol = typeof t.initial === 'number' && typeof t.final === 'number' ? Math.max(0, t.final - t.initial) : 0;
+                        return (
+                          <tr key={idx} className="border-t">
+                            <td className="py-2 pr-4">{idx + 1}</td>
+                            <td className="py-2 pr-4">
+                              <input
+                                type="number"
+                                inputMode="decimal"
+                                value={t.initial as any}
+                                onChange={(e) => {
+                                  const v = e.target.value;
+                                  setUserTrials(prev => prev.map((row, i) => i === idx ? { ...row, initial: v === "" ? "" : Number(v) } : row));
+                                }}
+                                className="w-24 border rounded px-2 py-1"
+                              />
+                            </td>
+                            <td className="py-2 pr-4">
+                              <input
+                                type="number"
+                                inputMode="decimal"
+                                value={t.final as any}
+                                onChange={(e) => {
+                                  const v = e.target.value;
+                                  setUserTrials(prev => prev.map((row, i) => i === idx ? { ...row, final: v === "" ? "" : Number(v) } : row));
+                                }}
+                                className="w-24 border rounded px-2 py-1"
+                              />
+                            </td>
+                            <td className="py-2 pr-4 font-mono">{vol.toFixed(2)}</td>
+                            <td className="py-2">
+                              <Button
+                                variant="outline"
+                                size="sm"
+                                onClick={() => setUserTrials(prev => prev.filter((_, i) => i !== idx))}
+                              >
+                                Remove
+                              </Button>
+                            </td>
+                          </tr>
+                        );
+                      })}
+                    </tbody>
+                  </table>
+                  <div className="mt-3">
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      onClick={() => setUserTrials(prev => [...prev, { initial: "", final: "" }])}
+                    >
+                      + Add Trial
+                    </Button>
+                  </div>
+                </div>
+
+                <div className="mt-4 grid grid-cols-1 md:grid-cols-3 gap-3">
+                  <div className="bg-gray-50 rounded p-3">
+                    <div className="text-xs text-gray-600">Mean Titre Volume (V₂)</div>
+                    <div className="text-lg font-bold">{meanV2.toFixed(2)} mL</div>
+                  </div>
+                  <div className="bg-gray-50 rounded p-3">
+                    <div className="text-xs text-gray-600">NaOH Normality (N₂)</div>
+                    <div className="text-lg font-bold">{naohNormalityUser.toFixed(4)} N</div>
+                  </div>
+                  <div className="bg-gray-50 rounded p-3">
+                    <div className="text-xs text-gray-600">Strength</div>
+                    <div className="text-lg font-bold">{naohStrengthUser.toFixed(2)} g/L</div>
+                  </div>
+                </div>
+              </div>
+            )}
             <div className="bg-white/90 backdrop-blur-sm rounded-xl p-4 border border-gray-200 shadow-sm">
               <h3 className="text-lg font-semibold text-gray-800 mb-4 flex items-center">
                 <Info className="w-5 h-5 mr-2 text-green-600" />

--- a/client/src/experiments/Titration1/components/VirtualLab.tsx
+++ b/client/src/experiments/Titration1/components/VirtualLab.tsx
@@ -85,6 +85,9 @@ export default function VirtualLab({
   const [showTitrating, setShowTitrating] = useState(false);
   const [titrationData, setTitrationData] = useState<TitrationData[]>([]);
   const [currentTrial, setCurrentTrial] = useState(1);
+  const [userTrials, setUserTrials] = useState<Array<{ initial: number | ""; final: number | "" }>>([{ initial: "", final: "" }]);
+  const [acidNormality, setAcidNormality] = useState<number | "">("");
+  const [acidVolume, setAcidVolume] = useState<number | "">("");
   const timeoutsRef = useRef<number[]>([]);
   const colorIntervalRef = useRef<number | null>(null);
 
@@ -614,10 +617,6 @@ export default function VirtualLab({
       // Set experiment as completed
       setExperimentCompleted(true);
       
-      // Auto-show results after delay
-      setTimeout(() => {
-        setShowResultsModal(true);
-      }, 5000);
 
     } else {
       setShowToast("Follow the current step instructions");
@@ -685,7 +684,7 @@ export default function VirtualLab({
     <TooltipProvider>
       <div className="w-full h-full bg-gradient-to-br from-gray-50 via-blue-50 to-purple-50 p-6">
         {/* Step Progress Bar (guided mode only) */}
-        {mode.current === 'guided' && (
+        {mode.current === 'guided' && !experimentCompleted && (
         <div className="mb-6 bg-white/90 backdrop-blur-sm rounded-xl p-4 border border-blue-200 shadow-sm">
           <div className="flex items-center justify-between mb-4">
             <h3 className="text-lg font-semibold text-gray-800">Titration Progress</h3>
@@ -782,15 +781,6 @@ export default function VirtualLab({
               </div>
             </div>
 
-            {/* Results Button - Only show when experiment is completed */}
-            {experimentCompleted && (
-              <Button
-                onClick={() => setShowResultsModal(true)}
-                className="w-full bg-green-500 hover:bg-green-600 text-white font-semibold"
-              >
-                📊 View Results & Analysis
-              </Button>
-            )}
 
             {/* Reset Button */}
             <Button
@@ -946,7 +936,7 @@ export default function VirtualLab({
               )}
 
               {/* Steps Completed (guided mode only) */}
-              {mode.current === 'guided' && (
+              {mode.current === 'guided' && !experimentCompleted && (
               <div className="mb-4">
                 <h4 className="font-semibold text-sm text-gray-700 mb-2">Completed Steps</h4>
                 <div className="space-y-1">

--- a/client/src/experiments/Titration1/components/VirtualLab.tsx
+++ b/client/src/experiments/Titration1/components/VirtualLab.tsx
@@ -631,6 +631,7 @@ export default function VirtualLab({
       
       // Set experiment as completed
       setExperimentCompleted(true);
+      setLocation(`/experiment/${experimentId}/results`);
       
 
     } else {

--- a/client/src/experiments/Titration1/components/VirtualLab.tsx
+++ b/client/src/experiments/Titration1/components/VirtualLab.tsx
@@ -782,7 +782,7 @@ export default function VirtualLab({
               <h4 className="text-sm font-semibold text-gray-700 mb-3">Chemical Reaction</h4>
               <div className="text-center text-xs font-mono leading-relaxed bg-gray-50 rounded-lg p-3 border">
                 <div className="mb-2">
-                  H₂C₂O₄ + 2NaOH → Na���C₂O₄ + 2H₂O
+                  H₂C₂O₄ + 2NaOH → Na₂C₂O₄ + 2H₂O
                 </div>
                 <div className="text-gray-500">
                   Oxalic acid + Sodium hydroxide
@@ -1014,7 +1014,7 @@ export default function VirtualLab({
                 </div>
               </div>
             )}
-            <div className="bg-white/90 backdrop-blur-sm rounded-xl p-4 border border-gray-200 shadow-sm">
+            <div className={`${experimentCompleted ? "hidden" : ""} bg-white/90 backdrop-blur-sm rounded-xl p-4 border border-gray-200 shadow-sm`}>
               <h3 className="text-lg font-semibold text-gray-800 mb-4 flex items-center">
                 <Info className="w-5 h-5 mr-2 text-green-600" />
                 Live Analysis

--- a/client/src/experiments/Titration1/components/VirtualLab.tsx
+++ b/client/src/experiments/Titration1/components/VirtualLab.tsx
@@ -1268,6 +1268,8 @@ export default function VirtualLab({
                     setShowTitrationLimitWarning(false);
                     setConicalFlask(prev => ({ ...prev, colorHex: ENDPOINT_COLORS.OVERSHOOT }));
                     setTitrationState(prev => ({ ...prev, currentPhase: 'completed', flaskColor: ENDPOINT_COLORS.OVERSHOOT, explanation: 'Continued beyond limit (dark pink observed)' }));
+                    setExperimentCompleted(true);
+                    setLocation(`/experiment/${experimentId}/results`);
                   }}
                   className="bg-pink-600 hover:bg-pink-700 text-white"
                 >

--- a/client/src/experiments/Titration1/components/VirtualLab.tsx
+++ b/client/src/experiments/Titration1/components/VirtualLab.tsx
@@ -540,6 +540,17 @@ export default function VirtualLab({
         // Endpoint reached!
         animateColorTransition(conicalFlask.colorHex, ENDPOINT_COLORS.ENDPOINT, 'endpoint');
         setConicalFlask(prev => ({ ...prev, endpointReached: true }));
+
+        // Mark experiment as completed immediately when color changes
+        if (!experimentCompleted) {
+          const finalReading = newReading;
+          const titreVolume = finalReading;
+          setTitrationData(prev => [...prev, { trial: currentTrial, initialReading: 0.0, finalReading, volume: titreVolume, isValid: true }]);
+          setTitrationState(prev => ({ ...prev, currentPhase: 'completed', titrationComplete: true }));
+          setShowToast('✅ Endpoint confirmed! Titration complete!');
+          setTimeout(() => setShowToast(''), 3000);
+          setExperimentCompleted(true);
+        }
         
         const logEntry: TitrationLog = {
           id: Date.now().toString(),

--- a/client/src/experiments/Titration1/components/VirtualLab.tsx
+++ b/client/src/experiments/Titration1/components/VirtualLab.tsx
@@ -680,6 +680,15 @@ export default function VirtualLab({
 
   const currentStepData = GUIDED_STEPS[currentStep - 1];
 
+  const validTrialVolumes = userTrials
+    .map(t => (typeof t.initial === 'number' && typeof t.final === 'number' ? Math.max(0, t.final - t.initial) : null))
+    .filter((v): v is number => v !== null && !Number.isNaN(v));
+  const meanV2 = validTrialVolumes.length ? validTrialVolumes.reduce((a, b) => a + b, 0) / validTrialVolumes.length : 0;
+  const nAcid = typeof acidNormality === 'number' ? acidNormality : 0;
+  const vAcid = typeof acidVolume === 'number' ? acidVolume : 0;
+  const naohNormalityUser = meanV2 > 0 && nAcid > 0 && vAcid > 0 ? (nAcid * vAcid) / meanV2 : 0;
+  const naohStrengthUser = naohNormalityUser * 40;
+
   return (
     <TooltipProvider>
       <div className="w-full h-full bg-gradient-to-br from-gray-50 via-blue-50 to-purple-50 p-6">

--- a/client/src/experiments/Titration1/components/VirtualLab.tsx
+++ b/client/src/experiments/Titration1/components/VirtualLab.tsx
@@ -762,7 +762,7 @@ export default function VirtualLab({
 
         <div className="grid grid-cols-1 lg:grid-cols-12 gap-6 h-full">
           {/* Equipment Section - Left */}
-          <div className="lg:col-span-3 space-y-4">
+          <div className={`${experimentCompleted ? "hidden" : ""} lg:col-span-3 space-y-4`}>
             <div className="bg-white/90 backdrop-blur-sm rounded-xl p-4 border border-gray-200 shadow-sm">
               <h3 className="text-lg font-semibold text-gray-800 mb-4 flex items-center">
                 <Wrench className="w-5 h-5 mr-2 text-blue-600" />

--- a/client/src/experiments/Titration1/components/VirtualLab.tsx
+++ b/client/src/experiments/Titration1/components/VirtualLab.tsx
@@ -1256,6 +1256,8 @@ export default function VirtualLab({
                     setShowTitrationLimitWarning(false);
                     setConicalFlask(prev => ({ ...prev, colorHex: ENDPOINT_COLORS.ENDPOINT, endpointReached: true }));
                     setTitrationState(prev => ({ ...prev, currentPhase: 'endpoint', flaskColor: ENDPOINT_COLORS.ENDPOINT, explanation: 'Stopped at safe limit (light pink observed)' }));
+                    setExperimentCompleted(true);
+                    setLocation(`/experiment/${experimentId}/results`);
                   }}
                   className="border-pink-300 text-pink-700 hover:bg-pink-50"
                 >

--- a/client/src/experiments/Titration1/components/VirtualLab.tsx
+++ b/client/src/experiments/Titration1/components/VirtualLab.tsx
@@ -4,7 +4,7 @@ import { Button } from "@/components/ui/button";
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogDescription } from "@/components/ui/dialog";
 import { Input } from "@/components/ui/input";
 import { FlaskConical, Beaker, Droplets, Info, ArrowRight, ArrowLeft, CheckCircle, Wrench, Calculator, TrendingUp, Clock, Home, FastForward } from "lucide-react";
-import { Link } from "wouter";
+import { Link, useLocation } from "wouter";
 import WorkBench from "./WorkBench";
 import Equipment, { LAB_EQUIPMENT } from "./Equipment";
 import {
@@ -40,6 +40,7 @@ interface VirtualLabProps {
   onReset: () => void;
   completedSteps: number[];
   burettePreparationComplete: boolean;
+  experimentId: number;
 }
 
 export default function VirtualLab({
@@ -53,6 +54,7 @@ export default function VirtualLab({
   onReset,
   completedSteps,
   burettePreparationComplete,
+  experimentId,
 }: VirtualLabProps) {
   // Lab state
   const [conicalFlask, setConicalFlask] = useState<ConicalFlask>(INITIAL_FLASK);
@@ -90,6 +92,7 @@ export default function VirtualLab({
   const [acidVolume, setAcidVolume] = useState<number | "">("");
   const timeoutsRef = useRef<number[]>([]);
   const colorIntervalRef = useRef<number | null>(null);
+  const [, setLocation] = useLocation();
 
   // Step 1 pipette planning state
   const [showPipetteVolumeModal, setShowPipetteVolumeModal] = useState(false);
@@ -550,6 +553,7 @@ export default function VirtualLab({
           setShowToast('✅ Endpoint confirmed! Titration complete!');
           setTimeout(() => setShowToast(''), 3000);
           setExperimentCompleted(true);
+          setLocation(`/experiment/${experimentId}/results`);
         }
         
         const logEntry: TitrationLog = {

--- a/client/src/pages/titration-results.tsx
+++ b/client/src/pages/titration-results.tsx
@@ -1,0 +1,159 @@
+import React, { useState } from "react";
+import Header from "@/components/header";
+import { Button } from "@/components/ui/button";
+import { Link, useParams } from "wouter";
+
+export default function TitrationResultsPage() {
+  const { id } = useParams<{ id: string }>();
+  const experimentId = parseInt(id || "6");
+
+  const [acidNormality, setAcidNormality] = useState<string>("");
+  const [acidVolume, setAcidVolume] = useState<string>("");
+  const [trials, setTrials] = useState<Array<{ initial: string; final: string }>>([
+    { initial: "", final: "" },
+  ]);
+
+  const volumes = trials
+    .map((t) => {
+      const i = parseFloat(t.initial);
+      const f = parseFloat(t.final);
+      if (Number.isFinite(i) && Number.isFinite(f)) {
+        return Math.max(0, f - i);
+      }
+      return null;
+    })
+    .filter((v): v is number => v !== null);
+
+  const meanV2 = volumes.length ? volumes.reduce((a, b) => a + b, 0) / volumes.length : 0;
+  const n1 = parseFloat(acidNormality);
+  const v1 = parseFloat(acidVolume);
+  const validInputs = Number.isFinite(n1) && Number.isFinite(v1) && meanV2 > 0;
+  const n2 = validInputs ? (n1 * v1) / meanV2 : 0;
+  const strength = n2 * 40;
+
+  return (
+    <div className="min-h-screen bg-gray-50">
+      <Header />
+      <div className="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+        <div className="flex items-center justify-between mb-6">
+          <h1 className="text-2xl font-bold">Titration Results — Live Data</h1>
+          <Link href={`/experiment/${experimentId}`}>
+            <Button variant="outline">Back to Experiment</Button>
+          </Link>
+        </div>
+
+        <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
+          <div className="lg:col-span-2 bg-white rounded-xl p-4 border border-gray-200 shadow-sm">
+            <h2 className="text-lg font-semibold mb-4">Enter Your Readings</h2>
+
+            <div className="grid grid-cols-2 gap-4 mb-4">
+              <div>
+                <label className="block text-xs text-gray-600 mb-1">Oxalic Acid Normality (N₁)</label>
+                <input
+                  type="number"
+                  inputMode="decimal"
+                  value={acidNormality}
+                  onChange={(e) => setAcidNormality(e.target.value)}
+                  className="w-full border rounded px-3 py-2 text-sm"
+                />
+              </div>
+              <div>
+                <label className="block text-xs text-gray-600 mb-1">Oxalic Acid Volume (V₁, mL)</label>
+                <input
+                  type="number"
+                  inputMode="decimal"
+                  value={acidVolume}
+                  onChange={(e) => setAcidVolume(e.target.value)}
+                  className="w-full border rounded px-3 py-2 text-sm"
+                />
+              </div>
+            </div>
+
+            <div className="overflow-x-auto">
+              <table className="min-w-full text-sm">
+                <thead>
+                  <tr className="text-left text-gray-600">
+                    <th className="py-2 pr-4">Trial</th>
+                    <th className="py-2 pr-4">Initial (mL)</th>
+                    <th className="py-2 pr-4">Final (mL)</th>
+                    <th className="py-2 pr-4">NaOH Used (mL)</th>
+                    <th className="py-2"></th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {trials.map((t, idx) => {
+                    const i = parseFloat(t.initial);
+                    const f = parseFloat(t.final);
+                    const vol = Number.isFinite(i) && Number.isFinite(f) ? Math.max(0, f - i) : 0;
+                    return (
+                      <tr key={idx} className="border-t">
+                        <td className="py-2 pr-4">{idx + 1}</td>
+                        <td className="py-2 pr-4">
+                          <input
+                            type="number"
+                            inputMode="decimal"
+                            value={t.initial}
+                            onChange={(e) =>
+                              setTrials((prev) => prev.map((row, i2) => (i2 === idx ? { ...row, initial: e.target.value } : row)))
+                            }
+                            className="w-24 border rounded px-2 py-1"
+                          />
+                        </td>
+                        <td className="py-2 pr-4">
+                          <input
+                            type="number"
+                            inputMode="decimal"
+                            value={t.final}
+                            onChange={(e) =>
+                              setTrials((prev) => prev.map((row, i2) => (i2 === idx ? { ...row, final: e.target.value } : row)))
+                            }
+                            className="w-24 border rounded px-2 py-1"
+                          />
+                        </td>
+                        <td className="py-2 pr-4 font-mono">{vol.toFixed(2)}</td>
+                        <td className="py-2">
+                          <Button
+                            variant="outline"
+                            size="sm"
+                            onClick={() => setTrials((prev) => prev.filter((_, i2) => i2 !== idx))}
+                          >
+                            Remove
+                          </Button>
+                        </td>
+                      </tr>
+                    );
+                  })}
+                </tbody>
+              </table>
+              <div className="mt-3">
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={() => setTrials((prev) => [...prev, { initial: "", final: "" }])}
+                >
+                  + Add Trial
+                </Button>
+              </div>
+            </div>
+          </div>
+
+          <div className="bg-white rounded-xl p-4 border border-gray-200 shadow-sm space-y-3">
+            <h2 className="text-lg font-semibold">Calculated Values</h2>
+            <div className="bg-gray-50 rounded p-3">
+              <div className="text-xs text-gray-600">Mean Titre Volume (V₂)</div>
+              <div className="text-lg font-bold">{meanV2.toFixed(2)} mL</div>
+            </div>
+            <div className="bg-gray-50 rounded p-3">
+              <div className="text-xs text-gray-600">NaOH Normality (N₂)</div>
+              <div className="text-lg font-bold">{n2.toFixed(4)} N</div>
+            </div>
+            <div className="bg-gray-50 rounded p-3">
+              <div className="text-xs text-gray-600">Strength</div>
+              <div className="text-lg font-bold">{strength.toFixed(2)} g/L</div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Purpose
Users requested a dedicated results page that appears after titration completion, replacing the previous modal-based results display. The goal was to implement a live data entry system where users can input their own trial readings and see real-time calculations of NaOH normality and strength using the N₁V₁ = N₂V₂ formula.

## Code changes
- **Added new route**: Created `/experiment/:id/results` route and `TitrationResultsPage` component
- **Modified experiment flow**: Removed post-titration steps and automatically redirect to results page when endpoint is reached
- **Implemented live data entry**: Added user input fields for acid normality, acid volume, and trial readings (initial/final burette readings)
- **Real-time calculations**: Added automatic calculation of mean titre volume, NaOH normality, and strength based on user inputs
- **Updated UI**: Hide equipment panel and analysis sections when experiment is completed, show live data entry instead
- **Enhanced navigation**: Added proper routing between experiment and results pagesTo clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 82`

🔗 [Edit in Builder.io](https://builder.io/app/projects/d61a21f3e88f486f983723a41091c219/cosmos-lab)

👀 [Preview Link](https://d61a21f3e88f486f983723a41091c219-cosmos-lab.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>d61a21f3e88f486f983723a41091c219</projectId>-->
<!--<branchName>cosmos-lab</branchName>-->