### PR TITLE
Auto-place china dish when distilled water is dropped

### DIFF
--- a/client/src/experiments/LassaigneTest/components/WorkBench.tsx
+++ b/client/src/experiments/LassaigneTest/components/WorkBench.tsx
@@ -203,7 +203,13 @@ export default function WorkBench({ step, totalSteps, equipmentItems, onNext, on
       setHistory((h) => [...h, { placed: prev }]);
       const withoutSame = prev.filter((p) => p.id !== eqId);
       const snapped = getSnapPosition(eqId, rect, withoutSame);
-      const next = [...withoutSame, { id: eqId, ...snapped }];
+      let next = [...withoutSame, { id: eqId, ...snapped }];
+
+      // If distilled water is dropped first, automatically place the china dish
+      if (eqId === "distilled-water" && !withoutSame.some((p) => p.id === "water-bath")) {
+        const dishSnap = getSnapPosition("water-bath", rect, withoutSame);
+        next = [...next, { id: "water-bath", ...dishSnap }];
+      }
 
       const tube = next.find((p) => p.id === "ignition-tube");
       const burner = next.find((p) => p.id === "bunsen-burner");


### PR DESCRIPTION
## Purpose
The user requested that when distilled water is dropped on the workbench, the china dish should automatically be filled with blue colored water. This enhancement improves the user experience by automating the placement of related equipment during the Lassaigne test experiment.

## Code changes
- Added logic in `WorkBench.tsx` to automatically place the water bath (china dish) when distilled water is dropped
- Implemented a condition check to ensure the water bath isn't already placed before auto-placing it
- Used existing `getSnapPosition` function to determine the appropriate placement position for the china dishTo clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 83`

🔗 [Edit in Builder.io](https://builder.io/app/projects/d61a21f3e88f486f983723a41091c219/zenith-garden)

👀 [Preview Link](https://d61a21f3e88f486f983723a41091c219-zenith-garden.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>d61a21f3e88f486f983723a41091c219</projectId>-->
<!--<branchName>zenith-garden</branchName>-->