### PR TITLE
Fix burette scale visibility and flask positioning

### DIFF
--- a/client/src/experiments/Titration1/components/Equipment.tsx
+++ b/client/src/experiments/Titration1/components/Equipment.tsx
@@ -199,7 +199,7 @@ export const Equipment: React.FC<EquipmentProps> = ({
               <img
                 src="https://cdn.builder.io/api/v1/image/assets%2Fc52292a04d4c4255a87bdaa80a28beb9%2F83364a0ee9aa408e91a299c5b7ef0886?format=webp&width=800"
                 alt="Conical Flask"
-                className={`h-40 w-auto object-contain transition-transform duration-200 ${isActive ? 'scale-105' : ''}`}
+                className={`h-48 w-auto object-contain transition-transform duration-200 ${isActive ? 'scale-105' : ''}`}
                 style={{ filter: 'drop-shadow(3px 3px 6px rgba(0,0,0,0.15))' }}
               />
               {/* Oxalic acid solution overlay */}

--- a/client/src/experiments/Titration1/components/Equipment.tsx
+++ b/client/src/experiments/Titration1/components/Equipment.tsx
@@ -100,8 +100,8 @@ export const Equipment: React.FC<EquipmentProps> = ({
         if (!workbench) return;
 
         const workbenchRect = workbench.getBoundingClientRect();
-        const equipmentWidth = id === 'burette' ? 200 : 80;
-        const equipmentHeight = id === 'burette' ? 420 : 80;
+        const equipmentWidth = id === 'burette' ? 200 : (id === 'conical-flask' ? 64 : 80);
+        const equipmentHeight = id === 'burette' ? 420 : (id === 'conical-flask' ? 64 : 80);
         const newX = Math.max(0, Math.min(moveEvent.clientX - workbenchRect.left - offsetX, workbenchRect.width - equipmentWidth));
         const newY = Math.max(0, Math.min(moveEvent.clientY - workbenchRect.top - offsetY, workbenchRect.height - equipmentHeight));
 

--- a/client/src/experiments/Titration1/components/Equipment.tsx
+++ b/client/src/experiments/Titration1/components/Equipment.tsx
@@ -144,7 +144,8 @@ export const Equipment: React.FC<EquipmentProps> = ({
       style={isPositioned ? {
         left: currentPosition.x,
         top: currentPosition.y,
-        transform: isActive ? 'scale(1.05)' : 'scale(1)'
+        transform: isActive ? 'scale(1.05)' : 'scale(1)',
+        zIndex: id === 'conical-flask' ? 60 : (id === 'burette' ? 50 : undefined)
       } : {}}
       draggable={!disabled && !isPositioned}
       onDragStart={handleDragStart}

--- a/client/src/experiments/Titration1/components/Equipment.tsx
+++ b/client/src/experiments/Titration1/components/Equipment.tsx
@@ -199,7 +199,7 @@ export const Equipment: React.FC<EquipmentProps> = ({
               <img
                 src="https://cdn.builder.io/api/v1/image/assets%2Fc52292a04d4c4255a87bdaa80a28beb9%2F83364a0ee9aa408e91a299c5b7ef0886?format=webp&width=800"
                 alt="Conical Flask"
-                className={`h-40 w-auto object-contain transition-transform duration-200 ${isActive ? 'scale-105' : ''}`}
+                className={`h-32 w-auto object-contain transition-transform duration-200 ${isActive ? 'scale-105' : ''}`}
                 style={{ filter: 'drop-shadow(3px 3px 6px rgba(0,0,0,0.15))' }}
               />
               {/* Oxalic acid solution overlay */}

--- a/client/src/experiments/Titration1/components/Equipment.tsx
+++ b/client/src/experiments/Titration1/components/Equipment.tsx
@@ -199,7 +199,7 @@ export const Equipment: React.FC<EquipmentProps> = ({
               <img
                 src="https://cdn.builder.io/api/v1/image/assets%2Fc52292a04d4c4255a87bdaa80a28beb9%2F83364a0ee9aa408e91a299c5b7ef0886?format=webp&width=800"
                 alt="Conical Flask"
-                className={`h-48 w-auto object-contain transition-transform duration-200 ${isActive ? 'scale-105' : ''}`}
+                className={`h-40 w-auto object-contain transition-transform duration-200 ${isActive ? 'scale-105' : ''}`}
                 style={{ filter: 'drop-shadow(3px 3px 6px rgba(0,0,0,0.15))' }}
               />
               {/* Oxalic acid solution overlay */}

--- a/client/src/experiments/Titration1/components/Equipment.tsx
+++ b/client/src/experiments/Titration1/components/Equipment.tsx
@@ -100,7 +100,7 @@ export const Equipment: React.FC<EquipmentProps> = ({
         if (!workbench) return;
 
         const workbenchRect = workbench.getBoundingClientRect();
-        const equipmentWidth = id === 'burette' ? 240 : 80;
+        const equipmentWidth = id === 'burette' ? 200 : 80;
         const equipmentHeight = id === 'burette' ? 420 : 80;
         const newX = Math.max(0, Math.min(moveEvent.clientX - workbenchRect.left - offsetX, workbenchRect.width - equipmentWidth));
         const newY = Math.max(0, Math.min(moveEvent.clientY - workbenchRect.top - offsetY, workbenchRect.height - equipmentHeight));
@@ -184,7 +184,7 @@ export const Equipment: React.FC<EquipmentProps> = ({
             <img
               src="https://cdn.builder.io/api/v1/image/assets%2Fc52292a04d4c4255a87bdaa80a28beb9%2F73ac259c4cb845619a548dafd6799255?format=webp&width=800"
               alt="Burette with NaOH solution"
-              className={`${currentStep >= 4 ? 'h-[500px]' : 'h-96'} w-auto object-contain transition-transform duration-200 ${isActive ? 'scale-105' : ''}`}
+              className={`${currentStep >= 4 ? 'h-[420px]' : 'h-80'} w-auto object-contain transition-transform duration-200 ${isActive ? 'scale-105' : ''}`}
               style={{ filter: 'drop-shadow(3px 3px 6px rgba(0,0,0,0.15))' }}
             />
             {flowing && (

--- a/client/src/experiments/Titration1/components/VirtualLab.tsx
+++ b/client/src/experiments/Titration1/components/VirtualLab.tsx
@@ -1258,7 +1258,7 @@ export default function VirtualLab({
                     setConicalFlask(prev => ({ ...prev, colorHex: ENDPOINT_COLORS.ENDPOINT, endpointReached: true }));
                     setTitrationState(prev => ({ ...prev, currentPhase: 'endpoint', flaskColor: ENDPOINT_COLORS.ENDPOINT, explanation: 'Stopped at safe limit (light pink observed)' }));
                     setExperimentCompleted(true);
-                    setSafeTimeout(() => setShowStrengthPrompt(true), 400);
+                    setSafeTimeout(() => setShowStrengthPrompt(true), 6000);
                   }}
                   className="border-pink-300 text-pink-700 hover:bg-pink-50"
                 >
@@ -1270,7 +1270,7 @@ export default function VirtualLab({
                     setConicalFlask(prev => ({ ...prev, colorHex: ENDPOINT_COLORS.OVERSHOOT }));
                     setTitrationState(prev => ({ ...prev, currentPhase: 'completed', flaskColor: ENDPOINT_COLORS.OVERSHOOT, explanation: 'Continued beyond limit (dark pink observed)' }));
                     setExperimentCompleted(true);
-                    setSafeTimeout(() => setShowStrengthPrompt(true), 400);
+                    setSafeTimeout(() => setShowStrengthPrompt(true), 6000);
                   }}
                   className="bg-pink-600 hover:bg-pink-700 text-white"
                 >

--- a/client/src/experiments/Titration1/components/VirtualLab.tsx
+++ b/client/src/experiments/Titration1/components/VirtualLab.tsx
@@ -497,7 +497,7 @@ export default function VirtualLab({
           const buretteEq = prev.find(e => e.id === 'burette');
           const bx = buretteEq?.position?.x ?? STEP_4_POSITIONS.burette.x;
           const by = buretteEq?.position?.y ?? STEP_4_POSITIONS.burette.y;
-          const newFlaskPos = { x: bx + 52, y: by + 235 };
+          const newFlaskPos = { x: bx + 80, y: by + 280 };
           return prev.map(eq => {
             if (eq.id === 'burette') return { ...eq, position: { x: bx, y: by } };
             if (eq.id === 'conical-flask') return { ...eq, position: newFlaskPos };

--- a/client/src/experiments/Titration1/components/VirtualLab.tsx
+++ b/client/src/experiments/Titration1/components/VirtualLab.tsx
@@ -899,7 +899,7 @@ export default function VirtualLab({
                           })}
                         </div>
 
-                        <div className="relative">
+                        <div className="relative" style={{ marginLeft: -60 }}>
                           <div style={{ width: 8, borderRadius: 8, background: 'linear-gradient(to bottom, rgba(59,130,246,0.95), rgba(99,102,241,0.95))', animation: 'pourStream 300ms linear forwards' }} className="origin-top" />
 
                           <div style={{ position: 'absolute', left: -6, top: 0 }}>

--- a/client/src/experiments/Titration1/components/VirtualLab.tsx
+++ b/client/src/experiments/Titration1/components/VirtualLab.tsx
@@ -497,7 +497,7 @@ export default function VirtualLab({
           const buretteEq = prev.find(e => e.id === 'burette');
           const bx = buretteEq?.position?.x ?? STEP_4_POSITIONS.burette.x;
           const by = buretteEq?.position?.y ?? STEP_4_POSITIONS.burette.y;
-          const newFlaskPos = { x: bx + 75, y: by + 250 };
+          const newFlaskPos = { x: bx + 85, y: by + 240 };
           return prev.map(eq => {
             if (eq.id === 'burette') return { ...eq, position: { x: bx, y: by } };
             if (eq.id === 'conical-flask') return { ...eq, position: newFlaskPos };

--- a/client/src/experiments/Titration1/components/VirtualLab.tsx
+++ b/client/src/experiments/Titration1/components/VirtualLab.tsx
@@ -497,7 +497,7 @@ export default function VirtualLab({
           const buretteEq = prev.find(e => e.id === 'burette');
           const bx = buretteEq?.position?.x ?? STEP_4_POSITIONS.burette.x;
           const by = buretteEq?.position?.y ?? STEP_4_POSITIONS.burette.y;
-          const newFlaskPos = { x: bx + 80, y: by + 280 };
+          const newFlaskPos = { x: bx + 60, y: by + 260 };
           return prev.map(eq => {
             if (eq.id === 'burette') return { ...eq, position: { x: bx, y: by } };
             if (eq.id === 'conical-flask') return { ...eq, position: newFlaskPos };

--- a/client/src/experiments/Titration1/components/VirtualLab.tsx
+++ b/client/src/experiments/Titration1/components/VirtualLab.tsx
@@ -1277,7 +1277,7 @@ export default function VirtualLab({
                     setConicalFlask(prev => ({ ...prev, colorHex: ENDPOINT_COLORS.ENDPOINT, endpointReached: true }));
                     setTitrationState(prev => ({ ...prev, currentPhase: 'endpoint', flaskColor: ENDPOINT_COLORS.ENDPOINT, explanation: 'Stopped at safe limit (light pink observed)' }));
                     setExperimentCompleted(true);
-                    setLocation(`/experiment/${experimentId}/results`);
+                    setSafeTimeout(() => setShowStrengthPrompt(true), 6000);
                   }}
                   className="border-pink-300 text-pink-700 hover:bg-pink-50"
                 >
@@ -1289,7 +1289,7 @@ export default function VirtualLab({
                     setConicalFlask(prev => ({ ...prev, colorHex: ENDPOINT_COLORS.OVERSHOOT }));
                     setTitrationState(prev => ({ ...prev, currentPhase: 'completed', flaskColor: ENDPOINT_COLORS.OVERSHOOT, explanation: 'Continued beyond limit (dark pink observed)' }));
                     setExperimentCompleted(true);
-                    setLocation(`/experiment/${experimentId}/results`);
+                    setSafeTimeout(() => setShowStrengthPrompt(true), 6000);
                   }}
                   className="bg-pink-600 hover:bg-pink-700 text-white"
                 >

--- a/client/src/experiments/Titration1/components/VirtualLab.tsx
+++ b/client/src/experiments/Titration1/components/VirtualLab.tsx
@@ -859,7 +859,7 @@ export default function VirtualLab({
                 const buretteOnBench = equipmentOnBench.find(e => e.id === 'burette');
                 const flaskOnBench = equipmentOnBench.find(e => e.id === 'conical-flask');
                 const left = (buretteOnBench?.position?.x ?? 120);
-                const top = (buretteOnBench?.position?.y ?? 100) + 200; // adjust to tip
+                const top = (buretteOnBench?.position?.y ?? 100) + 180; // adjust to tip
 
                 return (
                   <>

--- a/client/src/experiments/Titration1/components/VirtualLab.tsx
+++ b/client/src/experiments/Titration1/components/VirtualLab.tsx
@@ -878,7 +878,7 @@ export default function VirtualLab({
                 const buretteOnBench = equipmentOnBench.find(e => e.id === 'burette');
                 const flaskOnBench = equipmentOnBench.find(e => e.id === 'conical-flask');
                 const left = (buretteOnBench?.position?.x ?? 120);
-                const top = (buretteOnBench?.position?.y ?? 100) + 190; // adjust to tip
+                const top = (buretteOnBench?.position?.y ?? 100) + 185; // adjust to tip
 
                 return (
                   <>

--- a/client/src/experiments/Titration1/components/VirtualLab.tsx
+++ b/client/src/experiments/Titration1/components/VirtualLab.tsx
@@ -838,7 +838,7 @@ export default function VirtualLab({
           </div>
 
           {/* Workbench - Center */}
-          <div className="lg:col-span-6">
+          <div className="lg:col-span-5">
             <WorkBench
               onDrop={handleEquipmentDrop}
               isRunning={isRunning}

--- a/client/src/experiments/Titration1/components/VirtualLab.tsx
+++ b/client/src/experiments/Titration1/components/VirtualLab.tsx
@@ -838,7 +838,7 @@ export default function VirtualLab({
           </div>
 
           {/* Workbench - Center */}
-          <div className="lg:col-span-5">
+          <div className="lg:col-span-6">
             <WorkBench
               onDrop={handleEquipmentDrop}
               isRunning={isRunning}

--- a/client/src/experiments/Titration1/components/VirtualLab.tsx
+++ b/client/src/experiments/Titration1/components/VirtualLab.tsx
@@ -1277,7 +1277,7 @@ export default function VirtualLab({
                     setConicalFlask(prev => ({ ...prev, colorHex: ENDPOINT_COLORS.ENDPOINT, endpointReached: true }));
                     setTitrationState(prev => ({ ...prev, currentPhase: 'endpoint', flaskColor: ENDPOINT_COLORS.ENDPOINT, explanation: 'Stopped at safe limit (light pink observed)' }));
                     setExperimentCompleted(true);
-                    setSafeTimeout(() => setShowStrengthPrompt(true), 6000);
+                    setLocation(`/experiment/${experimentId}/results`);
                   }}
                   className="border-pink-300 text-pink-700 hover:bg-pink-50"
                 >
@@ -1289,7 +1289,7 @@ export default function VirtualLab({
                     setConicalFlask(prev => ({ ...prev, colorHex: ENDPOINT_COLORS.OVERSHOOT }));
                     setTitrationState(prev => ({ ...prev, currentPhase: 'completed', flaskColor: ENDPOINT_COLORS.OVERSHOOT, explanation: 'Continued beyond limit (dark pink observed)' }));
                     setExperimentCompleted(true);
-                    setSafeTimeout(() => setShowStrengthPrompt(true), 6000);
+                    setLocation(`/experiment/${experimentId}/results`);
                   }}
                   className="bg-pink-600 hover:bg-pink-700 text-white"
                 >

--- a/client/src/experiments/Titration1/components/VirtualLab.tsx
+++ b/client/src/experiments/Titration1/components/VirtualLab.tsx
@@ -486,15 +486,17 @@ export default function VirtualLab({
         setShowToast('2-3 drops of phanolpthalein added');
         setSafeTimeout(() => setShowToast(""), 3000);
         // Align flask under burette immediately after adding indicator
-        setEquipmentOnBench(prev => prev.map(eq => {
-          if (eq.id === 'burette' && STEP_4_POSITIONS.burette) {
-            return { ...eq, position: STEP_4_POSITIONS.burette };
-          }
-          if (eq.id === 'conical-flask' && STEP_4_POSITIONS['conical-flask']) {
-            return { ...eq, position: STEP_4_POSITIONS['conical-flask'] };
-          }
-          return eq;
-        }));
+        setEquipmentOnBench(prev => {
+          const buretteEq = prev.find(e => e.id === 'burette');
+          const bx = buretteEq?.position?.x ?? STEP_4_POSITIONS.burette.x;
+          const by = buretteEq?.position?.y ?? STEP_4_POSITIONS.burette.y;
+          const newFlaskPos = { x: bx + 52, y: by + 235 };
+          return prev.map(eq => {
+            if (eq.id === 'burette') return { ...eq, position: { x: bx, y: by } };
+            if (eq.id === 'conical-flask') return { ...eq, position: newFlaskPos };
+            return eq;
+          });
+        });
         handleStepComplete();
       }, ANIMATION.MIXING_DURATION);
 

--- a/client/src/experiments/Titration1/components/VirtualLab.tsx
+++ b/client/src/experiments/Titration1/components/VirtualLab.tsx
@@ -884,15 +884,15 @@ export default function VirtualLab({
                   <>
                     <style>{`@keyframes pourStream { 0% { height: 0 } 100% { height: 120px } } @keyframes dripFall { 0% { transform: translateY(0); opacity:1 } 80% { opacity:1 } 100% { transform: translateY(120px); opacity:0 } }`}</style>
 
-                    <div className="absolute pointer-events-none" style={{ left: left + 60, top, zIndex: 80 }}>
+                    <div className="absolute pointer-events-none" style={{ left: left + 120, top, zIndex: 80 }}>
                       <div className="flex items-start space-x-3">
-                        {/* Burette scale (downcounting 10→1) */}
-                        <div className="flex flex-col items-center bg-white p-3 rounded-lg shadow-xl ring-2 ring-blue-200" style={{ width: 80, zIndex: 70 }}>
+                        {/* Burette scale (downcounting 10→1) - moved to side */}
+                        <div className="flex flex-col items-center bg-white p-2 rounded-md shadow-lg ring-1 ring-blue-200" style={{ width: 60, zIndex: 70 }}>
                           {Array.from({ length: 10 }).map((_, idx) => {
                             const n = 10 - idx; // Downcount from 10 to 1
                             const used = burette.reading >= (10 - n + 1); // Show as used when passed
                             return (
-                              <div key={n} className={`w-full text-center text-base font-semibold py-1 mb-0.5 ${used ? 'bg-pink-600 text-white rounded shadow-sm' : 'text-gray-900 bg-gray-50 rounded border'}`}>
+                              <div key={n} className={`w-full text-center text-xs font-medium py-0.5 mb-0.5 ${used ? 'bg-pink-600 text-white rounded' : 'text-gray-800 bg-gray-100 rounded'}`}>
                                 {n} mL
                               </div>
                             );

--- a/client/src/experiments/Titration1/components/VirtualLab.tsx
+++ b/client/src/experiments/Titration1/components/VirtualLab.tsx
@@ -1281,6 +1281,34 @@ export default function VirtualLab({
           </DialogContent>
         </Dialog>
 
+        {/* Strength calculation prompt */}
+        <Dialog open={showStrengthPrompt} onOpenChange={setShowStrengthPrompt}>
+          <DialogContent className="max-w-md w-full p-0 rounded-xl overflow-hidden">
+            <div className="bg-gradient-to-br from-pink-600 via-rose-500 to-fuchsia-600 p-6 relative">
+              <div className="absolute inset-0 opacity-20 bg-[radial-gradient(circle_at_20%_20%,white,transparent_30%),radial-gradient(circle_at_80%_30%,white,transparent_30%)]" />
+              <div className="relative z-10 flex items-center">
+                <div className="bg-white/20 backdrop-blur-sm rounded-xl p-3 mr-3">
+                  <Calculator className="w-6 h-6 text-white" />
+                </div>
+                <div>
+                  <h3 className="text-white text-xl font-bold tracking-tight">Calculate the Strength of NaOH</h3>
+                  <p className="text-pink-100 text-sm mt-1">The solution color is set. Proceed to compute normality and strength.</p>
+                </div>
+              </div>
+            </div>
+            <div className="bg-white p-5">
+              <div className="flex items-center mb-4">
+                <span className="w-3 h-3 rounded-full mr-2" style={{ backgroundColor: conicalFlask.colorHex }} />
+                <span className="text-sm text-gray-600">Flask color preview</span>
+              </div>
+              <div className="flex justify-end gap-2">
+                <Button variant="outline" onClick={() => setShowStrengthPrompt(false)}>Stay</Button>
+                <Button className="bg-gradient-to-r from-pink-600 to-fuchsia-600 text-white" onClick={() => { setShowStrengthPrompt(false); setLocation(`/experiment/${experimentId}/results`); }}>Go to calculation</Button>
+              </div>
+            </div>
+          </DialogContent>
+        </Dialog>
+
         {/* Results Analysis Modal */}
         <Dialog open={showResultsModal} onOpenChange={setShowResultsModal}>
           <DialogContent className="max-w-4xl max-h-[90vh] overflow-y-auto">

--- a/client/src/experiments/Titration1/components/VirtualLab.tsx
+++ b/client/src/experiments/Titration1/components/VirtualLab.tsx
@@ -869,7 +869,7 @@ export default function VirtualLab({
                 const buretteOnBench = equipmentOnBench.find(e => e.id === 'burette');
                 const flaskOnBench = equipmentOnBench.find(e => e.id === 'conical-flask');
                 const left = (buretteOnBench?.position?.x ?? 120);
-                const top = (buretteOnBench?.position?.y ?? 100) + 180; // adjust to tip
+                const top = (buretteOnBench?.position?.y ?? 100) + 190; // adjust to tip
 
                 return (
                   <>

--- a/client/src/experiments/Titration1/components/VirtualLab.tsx
+++ b/client/src/experiments/Titration1/components/VirtualLab.tsx
@@ -886,13 +886,13 @@ export default function VirtualLab({
 
                     <div className="absolute z-40 pointer-events-none" style={{ left: left + 60, top }}>
                       <div className="flex items-start space-x-3">
-                        {/* Count-up indicators 1..10 */}
-                        <div className="flex flex-col items-center bg-white p-2 rounded-md shadow-lg ring-1 ring-gray-200 z-50" style={{ width: 72 }}>
+                        {/* Burette scale (downcounting 10→1) */}
+                        <div className="flex flex-col items-center bg-white p-3 rounded-lg shadow-xl ring-2 ring-blue-200 z-50" style={{ width: 80 }}>
                           {Array.from({ length: 10 }).map((_, idx) => {
-                            const n = idx + 1;
-                            const filled = burette.reading >= n;
+                            const n = 10 - idx; // Downcount from 10 to 1
+                            const used = burette.reading >= (10 - n + 1); // Show as used when passed
                             return (
-                              <div key={n} className={`w-full text-center text-sm py-0.5 ${filled ? 'bg-pink-600 text-white rounded mb-0.5' : 'text-gray-800'}`}>
+                              <div key={n} className={`w-full text-center text-base font-semibold py-1 mb-0.5 ${used ? 'bg-pink-600 text-white rounded shadow-sm' : 'text-gray-900 bg-gray-50 rounded border'}`}>
                                 {n} mL
                               </div>
                             );

--- a/client/src/experiments/Titration1/components/VirtualLab.tsx
+++ b/client/src/experiments/Titration1/components/VirtualLab.tsx
@@ -485,6 +485,16 @@ export default function VirtualLab({
         setActiveEquipment("");
         setShowToast('2-3 drops of phanolpthalein added');
         setSafeTimeout(() => setShowToast(""), 3000);
+        // Align flask under burette immediately after adding indicator
+        setEquipmentOnBench(prev => prev.map(eq => {
+          if (eq.id === 'burette' && STEP_4_POSITIONS.burette) {
+            return { ...eq, position: STEP_4_POSITIONS.burette };
+          }
+          if (eq.id === 'conical-flask' && STEP_4_POSITIONS['conical-flask']) {
+            return { ...eq, position: STEP_4_POSITIONS['conical-flask'] };
+          }
+          return eq;
+        }));
         handleStepComplete();
       }, ANIMATION.MIXING_DURATION);
 

--- a/client/src/experiments/Titration1/components/VirtualLab.tsx
+++ b/client/src/experiments/Titration1/components/VirtualLab.tsx
@@ -191,12 +191,19 @@ export default function VirtualLab({
         const filtered = prev.filter(eq => eq.id !== 'phenolphthalein' && eq.id !== 'pipette');
 
         // Reposition burette and conical flask for better alignment in step 4
-        const repositioned = filtered.map(eq => {
-          if (eq.id === 'burette' && STEP_4_POSITIONS.burette) {
-            return { ...eq, position: STEP_4_POSITIONS.burette };
+        let bx = STEP_4_POSITIONS.burette.x;
+        let by = STEP_4_POSITIONS.burette.y;
+        const withBurette = filtered.map(eq => {
+          if (eq.id === 'burette') {
+            bx = eq.position?.x ?? bx;
+            by = eq.position?.y ?? by;
+            return { ...eq, position: { x: bx, y: by } };
           }
-          if (eq.id === 'conical-flask' && STEP_4_POSITIONS['conical-flask']) {
-            return { ...eq, position: STEP_4_POSITIONS['conical-flask'] };
+          return eq;
+        });
+        const repositioned = withBurette.map(eq => {
+          if (eq.id === 'conical-flask') {
+            return { ...eq, position: { x: bx + 52, y: by + 235 } };
           }
           return eq;
         });

--- a/client/src/experiments/Titration1/components/VirtualLab.tsx
+++ b/client/src/experiments/Titration1/components/VirtualLab.tsx
@@ -1291,7 +1291,7 @@ export default function VirtualLab({
                   <Calculator className="w-6 h-6 text-white" />
                 </div>
                 <div>
-                  <h3 className="text-white text-xl font-bold tracking-tight">Calculate the Strength of NaOH</h3>
+                  <h3 className="text-white text-xl font-bold tracking-tight">Calculate the strength of NaOH now</h3>
                   <p className="text-pink-100 text-sm mt-1">The solution color is set. Proceed to compute normality and strength.</p>
                 </div>
               </div>

--- a/client/src/experiments/Titration1/components/VirtualLab.tsx
+++ b/client/src/experiments/Titration1/components/VirtualLab.tsx
@@ -497,7 +497,7 @@ export default function VirtualLab({
           const buretteEq = prev.find(e => e.id === 'burette');
           const bx = buretteEq?.position?.x ?? STEP_4_POSITIONS.burette.x;
           const by = buretteEq?.position?.y ?? STEP_4_POSITIONS.burette.y;
-          const newFlaskPos = { x: bx + 60, y: by + 260 };
+          const newFlaskPos = { x: bx + 75, y: by + 250 };
           return prev.map(eq => {
             if (eq.id === 'burette') return { ...eq, position: { x: bx, y: by } };
             if (eq.id === 'conical-flask') return { ...eq, position: newFlaskPos };

--- a/client/src/experiments/Titration1/components/VirtualLab.tsx
+++ b/client/src/experiments/Titration1/components/VirtualLab.tsx
@@ -180,6 +180,7 @@ export default function VirtualLab({
   // Auto titration flow after start prompt
   const [autoTitrating, setAutoTitrating] = useState(false);
   const [showTitrationLimitWarning, setShowTitrationLimitWarning] = useState(false);
+  const [showStrengthPrompt, setShowStrengthPrompt] = useState(false);
   const autoFlowIntervalRef = useRef<number | null>(null);
   const prevBuretteReadingRef = useRef<number>(burette.reading);
 

--- a/client/src/experiments/Titration1/components/VirtualLab.tsx
+++ b/client/src/experiments/Titration1/components/VirtualLab.tsx
@@ -933,7 +933,7 @@ export default function VirtualLab({
           </div>
 
           {/* Analysis Panel - Right */}
-          <div className="lg:col-span-4 space-y-4">
+          <div className="lg:col-span-3 space-y-4">
             {experimentCompleted && (
               <div className="bg-white/90 backdrop-blur-sm rounded-xl p-4 border border-gray-200 shadow-sm">
                 <h3 className="text-lg font-semibold text-gray-800 mb-4">Live Data Entry</h3>

--- a/client/src/experiments/Titration1/components/VirtualLab.tsx
+++ b/client/src/experiments/Titration1/components/VirtualLab.tsx
@@ -878,12 +878,12 @@ export default function VirtualLab({
                     <div className="absolute z-40 pointer-events-none" style={{ left: left + 60, top }}>
                       <div className="flex items-start space-x-3">
                         {/* Count-up indicators 1..10 */}
-                        <div className="flex flex-col items-center bg-white/90 p-2 rounded-md shadow" style={{ width: 64 }}>
+                        <div className="flex flex-col items-center bg-white p-2 rounded-md shadow-lg ring-1 ring-gray-200 z-50" style={{ width: 72 }}>
                           {Array.from({ length: 10 }).map((_, idx) => {
                             const n = idx + 1;
                             const filled = burette.reading >= n;
                             return (
-                              <div key={n} className={`w-full text-center text-xs py-0.5 ${filled ? 'bg-pink-600 text-white rounded mb-0.5' : 'text-gray-400'}`}>
+                              <div key={n} className={`w-full text-center text-sm py-0.5 ${filled ? 'bg-pink-600 text-white rounded mb-0.5' : 'text-gray-800'}`}>
                                 {n} mL
                               </div>
                             );

--- a/client/src/experiments/Titration1/components/VirtualLab.tsx
+++ b/client/src/experiments/Titration1/components/VirtualLab.tsx
@@ -884,7 +884,7 @@ export default function VirtualLab({
                   <>
                     <style>{`@keyframes pourStream { 0% { height: 0 } 100% { height: 120px } } @keyframes dripFall { 0% { transform: translateY(0); opacity:1 } 80% { opacity:1 } 100% { transform: translateY(120px); opacity:0 } }`}</style>
 
-                    <div className="absolute z-40 pointer-events-none" style={{ left: left + 60, top }}>
+                    <div className="absolute pointer-events-none" style={{ left: left + 60, top, zIndex: 80 }}>
                       <div className="flex items-start space-x-3">
                         {/* Burette scale (downcounting 10→1) */}
                         <div className="flex flex-col items-center bg-white p-3 rounded-lg shadow-xl ring-2 ring-blue-200" style={{ width: 80, zIndex: 70 }}>

--- a/client/src/experiments/Titration1/components/VirtualLab.tsx
+++ b/client/src/experiments/Titration1/components/VirtualLab.tsx
@@ -884,7 +884,7 @@ export default function VirtualLab({
                   <>
                     <style>{`@keyframes pourStream { 0% { height: 0 } 100% { height: 120px } } @keyframes dripFall { 0% { transform: translateY(0); opacity:1 } 80% { opacity:1 } 100% { transform: translateY(120px); opacity:0 } }`}</style>
 
-                    <div className="absolute pointer-events-none" style={{ left: left + 120, top, zIndex: 80 }}>
+                    <div className="absolute pointer-events-none" style={{ left: left + 160, top, zIndex: 80 }}>
                       <div className="flex items-start space-x-3">
                         {/* Burette scale (downcounting 10→1) - moved to side */}
                         <div className="flex flex-col items-center bg-white p-2 rounded-md shadow-lg ring-1 ring-blue-200" style={{ width: 60, zIndex: 70 }}>

--- a/client/src/experiments/Titration1/components/VirtualLab.tsx
+++ b/client/src/experiments/Titration1/components/VirtualLab.tsx
@@ -887,7 +887,7 @@ export default function VirtualLab({
                     <div className="absolute z-40 pointer-events-none" style={{ left: left + 60, top }}>
                       <div className="flex items-start space-x-3">
                         {/* Burette scale (downcounting 10→1) */}
-                        <div className="flex flex-col items-center bg-white p-3 rounded-lg shadow-xl ring-2 ring-blue-200 z-50" style={{ width: 80 }}>
+                        <div className="flex flex-col items-center bg-white p-3 rounded-lg shadow-xl ring-2 ring-blue-200" style={{ width: 80, zIndex: 70 }}>
                           {Array.from({ length: 10 }).map((_, idx) => {
                             const n = 10 - idx; // Downcount from 10 to 1
                             const used = burette.reading >= (10 - n + 1); // Show as used when passed

--- a/client/src/experiments/Titration1/components/VirtualLab.tsx
+++ b/client/src/experiments/Titration1/components/VirtualLab.tsx
@@ -933,7 +933,7 @@ export default function VirtualLab({
           </div>
 
           {/* Analysis Panel - Right */}
-          <div className="lg:col-span-3 space-y-4">
+          <div className="lg:col-span-4 space-y-4">
             {experimentCompleted && (
               <div className="bg-white/90 backdrop-blur-sm rounded-xl p-4 border border-gray-200 shadow-sm">
                 <h3 className="text-lg font-semibold text-gray-800 mb-4">Live Data Entry</h3>

--- a/client/src/experiments/Titration1/components/VirtualLab.tsx
+++ b/client/src/experiments/Titration1/components/VirtualLab.tsx
@@ -878,7 +878,7 @@ export default function VirtualLab({
                 const buretteOnBench = equipmentOnBench.find(e => e.id === 'burette');
                 const flaskOnBench = equipmentOnBench.find(e => e.id === 'conical-flask');
                 const left = (buretteOnBench?.position?.x ?? 120);
-                const top = (buretteOnBench?.position?.y ?? 100) + 185; // adjust to tip
+                const top = (buretteOnBench?.position?.y ?? 100) + 190; // adjust to tip
 
                 return (
                   <>

--- a/client/src/experiments/Titration1/components/VirtualLab.tsx
+++ b/client/src/experiments/Titration1/components/VirtualLab.tsx
@@ -497,7 +497,7 @@ export default function VirtualLab({
           const buretteEq = prev.find(e => e.id === 'burette');
           const bx = buretteEq?.position?.x ?? STEP_4_POSITIONS.burette.x;
           const by = buretteEq?.position?.y ?? STEP_4_POSITIONS.burette.y;
-          const newFlaskPos = { x: bx + 95, y: by + 230 };
+          const newFlaskPos = { x: bx + 88, y: by + 245 };
           return prev.map(eq => {
             if (eq.id === 'burette') return { ...eq, position: { x: bx, y: by } };
             if (eq.id === 'conical-flask') return { ...eq, position: newFlaskPos };

--- a/client/src/experiments/Titration1/components/VirtualLab.tsx
+++ b/client/src/experiments/Titration1/components/VirtualLab.tsx
@@ -899,7 +899,7 @@ export default function VirtualLab({
                           })}
                         </div>
 
-                        <div className="relative" style={{ marginLeft: -60 }}>
+                        <div className="relative" style={{ marginLeft: -100 }}>
                           <div style={{ width: 8, borderRadius: 8, background: 'linear-gradient(to bottom, rgba(59,130,246,0.95), rgba(99,102,241,0.95))', animation: 'pourStream 300ms linear forwards' }} className="origin-top" />
 
                           <div style={{ position: 'absolute', left: -6, top: 0 }}>

--- a/client/src/experiments/Titration1/components/VirtualLab.tsx
+++ b/client/src/experiments/Titration1/components/VirtualLab.tsx
@@ -497,7 +497,7 @@ export default function VirtualLab({
           const buretteEq = prev.find(e => e.id === 'burette');
           const bx = buretteEq?.position?.x ?? STEP_4_POSITIONS.burette.x;
           const by = buretteEq?.position?.y ?? STEP_4_POSITIONS.burette.y;
-          const newFlaskPos = { x: bx + 85, y: by + 240 };
+          const newFlaskPos = { x: bx + 95, y: by + 230 };
           return prev.map(eq => {
             if (eq.id === 'burette') return { ...eq, position: { x: bx, y: by } };
             if (eq.id === 'conical-flask') return { ...eq, position: newFlaskPos };

--- a/client/src/experiments/Titration1/components/VirtualLab.tsx
+++ b/client/src/experiments/Titration1/components/VirtualLab.tsx
@@ -1258,7 +1258,7 @@ export default function VirtualLab({
                     setConicalFlask(prev => ({ ...prev, colorHex: ENDPOINT_COLORS.ENDPOINT, endpointReached: true }));
                     setTitrationState(prev => ({ ...prev, currentPhase: 'endpoint', flaskColor: ENDPOINT_COLORS.ENDPOINT, explanation: 'Stopped at safe limit (light pink observed)' }));
                     setExperimentCompleted(true);
-                    setLocation(`/experiment/${experimentId}/results`);
+                    setSafeTimeout(() => setShowStrengthPrompt(true), 400);
                   }}
                   className="border-pink-300 text-pink-700 hover:bg-pink-50"
                 >
@@ -1270,7 +1270,7 @@ export default function VirtualLab({
                     setConicalFlask(prev => ({ ...prev, colorHex: ENDPOINT_COLORS.OVERSHOOT }));
                     setTitrationState(prev => ({ ...prev, currentPhase: 'completed', flaskColor: ENDPOINT_COLORS.OVERSHOOT, explanation: 'Continued beyond limit (dark pink observed)' }));
                     setExperimentCompleted(true);
-                    setLocation(`/experiment/${experimentId}/results`);
+                    setSafeTimeout(() => setShowStrengthPrompt(true), 400);
                   }}
                   className="bg-pink-600 hover:bg-pink-700 text-white"
                 >

--- a/client/src/experiments/Titration1/constants.ts
+++ b/client/src/experiments/Titration1/constants.ts
@@ -313,5 +313,5 @@ export const EQUIPMENT_POSITIONS = {
 // Step 4 specific positioning for better alignment
 export const STEP_4_POSITIONS = {
   'burette': { x: 80, y: 100 },
-  'conical-flask': { x: 140, y: 460 }
+  'conical-flask': { x: 140, y: 360 }
 };


### PR DESCRIPTION
## Purpose
The user requested improvements to the titration experiment interface to enhance visibility and positioning of key components. They wanted the burette scale readings (1ml, 2ml, 3ml) to be more visible, the flask to be properly positioned under the burette's pink tube, and the overall animation to be clearly visible from a sideways view.

## Code changes
- **Burette scale visibility**: Moved the scale display to the side with better styling, changed from count-up (1-10) to countdown format (10-1), and improved contrast with white background and ring styling
- **Flask positioning**: Reduced conical flask size from 160px to 128px (h-40 to h-32), adjusted equipment dimensions for better collision detection, and implemented automatic alignment under burette tip
- **Z-index layering**: Added proper z-index values to prevent elements from appearing behind equipment (flask: 60, burette: 50)
- **Burette sizing**: Reduced burette width from 240px to 200px and height adjustments for better proportions
- **Animation positioning**: Adjusted pour stream positioning and flask alignment coordinates for optimal visual flow
- **User flow**: Added strength calculation prompt dialog after titration completion instead of immediate redirectTo clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 84`

🔗 [Edit in Builder.io](https://builder.io/app/projects/d61a21f3e88f486f983723a41091c219/neon-realm)

👀 [Preview Link](https://d61a21f3e88f486f983723a41091c219-neon-realm.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>d61a21f3e88f486f983723a41091c219</projectId>-->
<!--<branchName>neon-realm</branchName>-->