### PR TITLE
Add volume validation with error messages for lab inputs

### DIFF
--- a/client/src/experiments/EquilibriumShift/components/VirtualLab.tsx
+++ b/client/src/experiments/EquilibriumShift/components/VirtualLab.tsx
@@ -74,6 +74,7 @@ export default function VirtualLab({
   const [showVolumeModal, setShowVolumeModal] = useState(false);
   const [selectedBottle, setSelectedBottle] = useState<string>("");
   const [volumeInput, setVolumeInput] = useState<string>("");
+  const [volumeError, setVolumeError] = useState<string | null>(null);
   const [observePulse, setObservePulse] = useState<boolean>(true);
   const [finalVolumeUsed, setFinalVolumeUsed] = useState<number | null>(null);
 
@@ -1082,11 +1083,28 @@ export default function VirtualLab({
                        selectedBottle === 'distilled-water' ? '3.0' : '50'}
                   step="0.1"
                   value={volumeInput}
-                  onChange={(e) => setVolumeInput(e.target.value)}
+                  onChange={(e) => {
+                    const val = e.target.value;
+                    setVolumeInput(val);
+                    const n = parseFloat(val);
+                    const max = selectedBottle === 'cobalt-ii-solution' ? 5.0 :
+                                 selectedBottle === 'concentrated-hcl' ? 2.0 :
+                                 selectedBottle === 'distilled-water' ? 3.0 : 50;
+                    if (Number.isNaN(n)) {
+                      setVolumeError('Enter a valid number');
+                    } else if (n < 0.1 || n > max) {
+                      setVolumeError(`Please enter a value between 0.1 and ${max} mL`);
+                    } else {
+                      setVolumeError(null);
+                    }
+                  }}
                   placeholder="Enter volume in mL"
                   className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent"
                   autoFocus
                 />
+                {volumeError && (
+                  <p className="text-xs text-red-600 mt-1">{volumeError}</p>
+                )}
                 <p className="text-xs text-gray-500 mt-1">
                   Recommended range: 0.1 - {selectedBottle === 'cobalt-ii-solution' ? '5.0' :
                                               selectedBottle === 'concentrated-hcl' ? '2.0' :
@@ -1101,6 +1119,7 @@ export default function VirtualLab({
                     setShowVolumeModal(false);
                     setVolumeInput("");
                     setSelectedBottle("");
+                    setVolumeError(null);
                   }}
                 >
                   Cancel
@@ -1112,15 +1131,15 @@ export default function VirtualLab({
                                      selectedBottle === 'concentrated-hcl' ? 2.0 :
                                      selectedBottle === 'distilled-water' ? 3.0 : 50;
 
-                    if (isNaN(volume) || volume <= 0 || volume > maxVolume) {
-                      setShowToast(`Please enter a valid volume between 0.1 and ${maxVolume} mL`);
-                      setTimeout(() => setShowToast(""), 3000);
+                    if (Number.isNaN(volume) || volume < 0.1 || volume > maxVolume) {
+                      setVolumeError(`Please enter a value between 0.1 and ${maxVolume} mL`);
                       return;
                     }
+                    setVolumeError(null);
                     handleVolumeSubmit(volume);
                   }}
                   className="bg-blue-500 hover:bg-blue-600 text-white"
-                  disabled={!volumeInput || isNaN(parseFloat(volumeInput))}
+                  disabled={!volumeInput || isNaN(parseFloat(volumeInput)) || !!volumeError}
                 >
                   Add Solution
                 </Button>

--- a/client/src/experiments/PHComparison/components/VirtualLab.tsx
+++ b/client/src/experiments/PHComparison/components/VirtualLab.tsx
@@ -38,6 +38,7 @@ export default function VirtualLab({ experimentStarted, onStartExperiment, isRun
   const [showHclDialog, setShowHclDialog] = useState(false);
   const [hclVolume, setHclVolume] = useState<string>("5.0");
   const [previewHclVolume, setPreviewHclVolume] = useState<number | null>(5.0);
+  const [hclError, setHclError] = useState<string | null>(null);
 
   useEffect(() => { setCurrentStep((mode.currentGuidedStep || 0) + 1); }, [mode.currentGuidedStep]);
 
@@ -159,9 +160,11 @@ export default function VirtualLab({ experimentStarted, onStartExperiment, isRun
 
   const confirmAddHcl = () => {
     const v = parseFloat(hclVolume);
-    if (Number.isNaN(v) || v <= 0) return setShowToast('Enter a valid volume');
-    const clamped = Math.min(10.0, Math.max(5.0, v));
-    addToTube('HCL', clamped);
+    if (Number.isNaN(v) || v < 5.0 || v > 10.0) {
+      setHclError('Please enter a value between 5.0 and 10.0 mL');
+      return;
+    }
+    addToTube('HCL', v);
     setShowHclDialog(false);
   };
 
@@ -299,15 +302,28 @@ export default function VirtualLab({ experimentStarted, onStartExperiment, isRun
               min={5.0}
               max={10.0}
               value={hclVolume}
-              onChange={(e) => { const val = e.target.value; setHclVolume(val); const parsed = parseFloat(val); if (!Number.isNaN(parsed)) setPreviewHclVolume(Math.min(10.0, Math.max(5.0, parsed))); else setPreviewHclVolume(null); }}
+              onChange={(e) => {
+                const val = e.target.value;
+                setHclVolume(val);
+                const parsed = parseFloat(val);
+                if (!Number.isNaN(parsed)) {
+                  setPreviewHclVolume(Math.min(10.0, Math.max(5.0, parsed)));
+                  if (parsed < 5.0 || parsed > 10.0) setHclError("Please enter a value between 5.0 and 10.0 mL");
+                  else setHclError(null);
+                } else {
+                  setPreviewHclVolume(null);
+                  setHclError("Enter a valid number");
+                }
+              }}
               className="w-full border rounded-md px-3 py-2"
               placeholder="Enter volume in mL"
             />
+            {hclError && <p className="text-xs text-red-600">{hclError}</p>}
             <p className="text-xs text-gray-500">Recommended range: 5.0 – 10.0 mL</p>
           </div>
           <DialogFooter>
             <Button variant="outline" onClick={() => setShowHclDialog(false)}>Cancel</Button>
-            <Button onClick={confirmAddHcl}>Add Solution</Button>
+            <Button onClick={confirmAddHcl} disabled={!!hclError || Number.isNaN(parseFloat(hclVolume)) || parseFloat(hclVolume) < 5.0 || parseFloat(hclVolume) > 10.0}>Add Solution</Button>
           </DialogFooter>
         </DialogContent>
       </Dialog>


### PR DESCRIPTION
## Purpose
The user requested to show error messages when values greater than the specified limits are assigned in the virtual lab components. They wanted consistent error handling for volume inputs across different experiments, specifically for ranges like 5.0-10.0ml.

## Code changes
- **EquilibriumShift VirtualLab**: Added `volumeError` state to track validation errors for volume inputs. Implemented real-time validation in the volume input onChange handler that checks for valid numbers and range limits (0.1-5.0ml for cobalt solution, 0.1-2.0ml for HCl, 0.1-3.0ml for distilled water). Added error message display below the input field and disabled the submit button when errors are present.

- **PHComparison VirtualLab**: Added `hclError` state for HCl volume validation. Implemented validation for the 5.0-10.0ml range with real-time error checking in the input onChange handler. Added error message display and disabled the submit button when validation fails.

Both components now provide immediate feedback to users when they enter invalid volume values, preventing submission of out-of-range inputs.To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 92`

🔗 [Edit in Builder.io](https://builder.io/app/projects/2e39ec5c2a9a458d870baa26b1d2b2e6/stellar-world)

👀 [Preview Link](https://2e39ec5c2a9a458d870baa26b1d2b2e6-stellar-world.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>2e39ec5c2a9a458d870baa26b1d2b2e6</projectId>-->
<!--<branchName>stellar-world</branchName>-->