### PR TITLE
Add test tube comparison feature with compare button

### DIFF
--- a/client/src/experiments/PHComparison/components/VirtualLab.tsx
+++ b/client/src/experiments/PHComparison/components/VirtualLab.tsx
@@ -336,7 +336,7 @@ export default function VirtualLab({ experimentStarted, onStartExperiment, isRun
               ))}
               {/* Comparison overlay */}
               {compareMode && (
-                <div className="absolute inset-0 flex items-end justify-center pb-2 pointer-events-none">
+                <div className="absolute inset-0 flex items-end justify-center pb-28 pointer-events-none">
                   <div className="grid grid-cols-2 gap-12">
                     <div className="flex flex-col items-center">
                       <div className="relative w-32 h-72">


### PR DESCRIPTION
## Purpose

The user wanted to implement a comparison feature for the pH experiment that allows students to visually compare two different acid solutions side by side. The workflow includes:
- Showing a "COMPARE" button when the solution turns yellow (acetic acid + indicator)
- When pressed, displaying both test tubes (HCl and acetic acid samples) for comparison
- Removing other equipment from the workbench to focus on the comparison
- Moving the test tubes to an elevated position for better visibility

## Code changes

- **Added comparison state management**: New state variables for `compareMode`, `hclSample`, and `aceticSample`
- **Automatic sample capture**: Added useEffect to automatically capture test tube snapshots when recognizable end-states are reached (HCl+indicator showing red, acetic acid+indicator showing yellow)
- **Compare button implementation**: Added conditional rendering of COMPARE button below test tube when acetic acid solution turns yellow
- **Comparison overlay**: Created new comparison view that displays both captured samples side by side with labels
- **Equipment filtering**: Modified workbench to hide other equipment during comparison mode
- **Button behavior**: Compare button is removed once pressed and triggers step completionTo clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 95`

🔗 [Edit in Builder.io](https://builder.io/app/projects/a55ddb97044646eeb89a54d5d7ff2250/zen-oasis)

👀 [Preview Link](https://a55ddb97044646eeb89a54d5d7ff2250-zen-oasis.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>a55ddb97044646eeb89a54d5d7ff2250</projectId>-->
<!--<branchName>zen-oasis</branchName>-->