### PR TITLE
Update experiment UI: add results modal and reset button

### DIFF
--- a/client/src/experiments/PHComparison/components/VirtualLab.tsx
+++ b/client/src/experiments/PHComparison/components/VirtualLab.tsx
@@ -335,7 +335,7 @@ export default function VirtualLab({ experimentStarted, onStartExperiment, isRun
                   <Equipment id="test-tube" name="20 mL Test Tube" icon={<TestTube className="w-8 h-8" />} position={getEquipmentPosition('test-tube')} onRemove={handleRemove} onInteract={() => {}} color={testTube.colorHex} volume={testTube.volume} displayVolume={showHclDialog && previewHclVolume != null ? previewHclVolume : showAceticDialog && previewAceticVolume != null ? previewAceticVolume : showIndicatorDialog && previewIndicatorVolume != null ? Math.min(20, testTube.volume + previewIndicatorVolume) : testTube.volume} isActive={true} />
                   {shouldShowRestore && (
                     <div style={{ position: 'absolute', left: getEquipmentPosition('test-tube').x, top: getEquipmentPosition('test-tube').y + 220, transform: 'translate(-50%, 0)' }}>
-                      <Button size="sm" variant="outline" className="bg-white border-gray-300 shadow-sm animate-pulse" onClick={handleRestore}>RESET</Button>
+                      <Button size="sm" className="bg-blue-500 hover:bg-blue-600 text-white shadow-sm animate-pulse" onClick={handleRestore}>RESET</Button>
                     </div>
                   )}
 


### PR DESCRIPTION
## Purpose

Based on the conversation history, the user requested several UI improvements for the pH comparison experiment:
- Display experiment summaries and final experimental states for both red and yellow solutions
- Remove color code references from the interface
- Change the restore button to "RESET" with a blinking effect and blue color
- Add comprehensive results analysis functionality

## Code changes

### Results Modal & Analysis
- Added new `LogEntry` interface to track experimental actions and observations
- Implemented comprehensive results modal with experiment summaries for both HCl and CH3COOH solutions
- Added action timeline showing step-by-step experimental progress with before/after color states
- Created final experimental state display for both solutions without color code references
- Added automatic modal opening after experiment completion (5-second delay)

### Button Updates
- Changed "RESTORE" button to "RESET" as requested
- Applied blue color styling (`bg-blue-500 hover:bg-blue-600`)
- Added blinking effect using `animate-pulse` class
- Removed previous outline styling in favor of solid blue design

### Enhanced Logging
- Integrated action logging throughout the experiment workflow
- Added detailed observations for each chemical addition
- Removed explicit color code mentions from user-facing text while maintaining internal color tracking

### UI Improvements
- Added new icons (TrendingUp, Clock, FlaskConical, Home) for better visual organization
- Implemented responsive grid layouts for experiment summaries
- Added navigation back to experiments listTo clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 96`

🔗 [Edit in Builder.io](https://builder.io/app/projects/a55ddb97044646eeb89a54d5d7ff2250/zenith-forge)

👀 [Preview Link](https://a55ddb97044646eeb89a54d5d7ff2250-zenith-forge.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>a55ddb97044646eeb89a54d5d7ff2250</projectId>-->
<!--<branchName>zenith-forge</branchName>-->