### PR TITLE
Add top-right navigation menu to hero section

### DIFF
--- a/client/src/components/hero-section.tsx
+++ b/client/src/components/hero-section.tsx
@@ -30,6 +30,30 @@ export default function HeroSection() {
           </Button>
         </div>
 
+        {/* Top-right menu logo button */}
+        <div className="absolute top-4 right-4 z-50">
+          <Dialog>
+            <DialogTrigger asChild>
+              <Button className="w-12 h-12 flex items-center justify-center rounded-full bg-emerald-700/80 hover:bg-emerald-700 text-white shadow-lg">
+                <span className="text-xl">☰</span>
+              </Button>
+            </DialogTrigger>
+
+            <DialogContent className="w-64 bg-emerald-900 text-white p-4 rounded-xl shadow-2xl">
+              <DialogHeader className="!p-0 mb-2">
+                <DialogTitle className="text-lg font-semibold">Menu</DialogTitle>
+                <DialogDescription className="text-sm text-amber-50/80">Quick links</DialogDescription>
+              </DialogHeader>
+
+              <div className="flex flex-col gap-3 mt-2">
+                <button onClick={() => { navigate('/about'); }} className="w-full text-left rounded px-3 py-2 bg-gradient-to-r from-amber-400 to-emerald-600 text-white font-medium">Know More About Us</button>
+
+                <button onClick={() => { const el = document.getElementById('about-assam'); if (el) el.scrollIntoView({ behavior: 'smooth' }); }} className="w-full text-left rounded px-3 py-2 bg-white text-emerald-800 font-medium">Contact Us</button>
+              </div>
+            </DialogContent>
+          </Dialog>
+        </div>
+
 
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
         <div className="text-center">

--- a/client/src/components/hero-section.tsx
+++ b/client/src/components/hero-section.tsx
@@ -1,5 +1,6 @@
 import { Button } from "@/components/ui/button";
 import { useLocation } from "wouter";
+import { useState } from "react";
 import SafetyGuideModal from "./safety-guide-modal";
 import SignInModal from "./sign-in-modal";
 import {
@@ -13,6 +14,8 @@ import {
 
 export default function HeroSection() {
   const [, navigate] = useLocation();
+  const [menuOpen, setMenuOpen] = useState(false);
+  const [aboutOpen, setAboutOpen] = useState(false);
 
   const scrollToExperiments = () => {
     const experimentsSection = document.getElementById('experiments');
@@ -32,7 +35,7 @@ export default function HeroSection() {
 
         {/* Top-right menu logo button */}
         <div className="absolute top-4 right-4 z-50">
-          <Dialog>
+          <Dialog open={menuOpen} onOpenChange={setMenuOpen}>
             <DialogTrigger asChild>
               <Button className="w-12 h-12 flex items-center justify-center rounded-full bg-emerald-700/80 hover:bg-emerald-700 text-white shadow-lg">
                 <span className="text-xl">☰</span>
@@ -46,7 +49,7 @@ export default function HeroSection() {
               </DialogHeader>
 
               <div className="flex flex-col gap-3 mt-2">
-                <button onClick={() => { navigate('/about'); }} className="w-full text-left rounded px-3 py-2 bg-gradient-to-r from-amber-400 to-emerald-600 text-white font-medium">Know More About Us</button>
+                <button onClick={() => { setMenuOpen(false); setAboutOpen(true); }} className="w-full text-left rounded px-3 py-2 bg-gradient-to-r from-amber-400 to-emerald-600 text-white font-medium">Know More About Us</button>
 
                 <button onClick={() => { const el = document.getElementById('about-assam'); if (el) el.scrollIntoView({ behavior: 'smooth' }); }} className="w-full text-left rounded px-3 py-2 bg-white text-emerald-800 font-medium">Contact Us</button>
               </div>
@@ -97,7 +100,7 @@ export default function HeroSection() {
             {/* Lower action buttons: left, center, right */}
             <div className="absolute left-0 right-0 bottom-6 px-4">
               <div className="max-w-7xl mx-auto flex flex-col md:flex-row items-center justify-between gap-4">
-                <Dialog>
+                <Dialog open={aboutOpen} onOpenChange={setAboutOpen}>
                   <DialogTrigger asChild>
                     <Button className="flex-1 md:flex-none bg-gradient-to-r from-amber-400 to-emerald-600 text-white px-5 py-3 rounded-full shadow-xl transform hover:scale-105 transition-transform duration-200 font-semibold tracking-wide font-serif">
                       <span className="mr-3 inline-flex items-center justify-center w-6 h-6 rounded-full bg-amber-100 text-amber-700">🔎</span>


### PR DESCRIPTION
## Summary
This PR adds a floating navigation menu button to the top-right corner of the hero section, providing quick access to "Know More About Us" and "Contact Us" features.

## Problem
The hero section lacked a dedicated menu for quick navigation to contact information or detailed information about the organization, limiting user accessibility to these key sections.

## Solution
Implemented an absolute-positioned hamburger menu button that opens a dialog containing navigation links. The "Know More About Us" link programmatically triggers the existing information modal, while "Contact Us" scrolls to the relevant section.

## Key Changes
- Added state management (`menuOpen`, `aboutOpen`) to control dialog visibility.
- Implemented a new top-right menu button using the `Dialog` component.
- Configured the menu's "Know More About Us" button to open the existing About dialog.
- Configured the "Contact Us" button to scroll to the `#about-assam` section.
- Updated the existing About dialog to accept controlled `open` state props.

<!-- FUSION_KEEP_START -->
<!-- FUSION_KEEP_END -->

🔗 [Edit in Builder.io](https://builder.io/app/projects/f4fe220e5aa74c738acc384f026a2e6d/zen-forge)

👀 [Preview Link](https://f4fe220e5aa74c738acc384f026a2e6d-zen-forge.projects.builder.my/)

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 110`



<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>f4fe220e5aa74c738acc384f026a2e6d</projectId>-->
<!--<branchName>zen-forge</branchName>-->